### PR TITLE
Use SpectralColor datatype for storing color data

### DIFF
--- a/intern/cycles/graph/node.cpp
+++ b/intern/cycles/graph/node.cpp
@@ -54,8 +54,7 @@ template<typename T> static T &get_socket_value(const Node *node, const SocketTy
 static bool is_socket_float3(const SocketType &socket)
 {
   return socket.type == SocketType::COLOR || socket.type == SocketType::POINT ||
-         socket.type == SocketType::VECTOR || socket.type == SocketType::NORMAL ||
-         socket.type == SocketType::SPECTRAL;
+         socket.type == SocketType::VECTOR || socket.type == SocketType::NORMAL;
 }
 
 static bool is_socket_array_float3(const SocketType &socket)
@@ -411,7 +410,7 @@ bool Node::equals_value(const Node &other, const SocketType &socket) const
     case SocketType::COLOR:
       return is_value_equal<float3>(this, &other, socket);
     case SocketType::SPECTRAL:
-      return is_value_equal<float3>(this, &other, socket);
+      return is_value_equal<SpectralColor>(this, &other, socket);
     case SocketType::VECTOR:
       return is_value_equal<float3>(this, &other, socket);
     case SocketType::POINT:
@@ -533,7 +532,7 @@ void Node::hash(MD5Hash &md5)
         float3_hash(this, socket, md5);
         break;
       case SocketType::SPECTRAL:
-        float3_hash(this, socket, md5);
+        value_hash<SpectralColor>(this, socket, md5);
         break;
       case SocketType::VECTOR:
         float3_hash(this, socket, md5);

--- a/intern/cycles/graph/node_type.cpp
+++ b/intern/cycles/graph/node_type.cpp
@@ -49,7 +49,7 @@ size_t SocketType::size(Type type)
     case COLOR:
       return sizeof(float3);
     case SPECTRAL:
-      return sizeof(float3);
+      return sizeof(SpectralColor);
     case VECTOR:
       return sizeof(float3);
     case POINT:
@@ -133,7 +133,7 @@ ustring SocketType::type_name(Type type)
 
 bool SocketType::is_float3(Type type)
 {
-  return (type == COLOR || type == VECTOR || type == POINT || type == NORMAL || type == SPECTRAL);
+  return (type == COLOR || type == VECTOR || type == POINT || type == NORMAL);
 }
 
 /* Node Type */

--- a/intern/cycles/graph/node_type.h
+++ b/intern/cycles/graph/node_type.h
@@ -191,7 +191,8 @@ struct NodeType {
 #define SOCKET_COLOR(name, ui_name, default_value, ...) \
   SOCKET_DEFINE(name, ui_name, default_value, float3, SocketType::COLOR, 0, ##__VA_ARGS__)
 #define SOCKET_SPECTRAL(name, ui_name, default_value, ...) \
-  SOCKET_DEFINE(name, ui_name, default_value, float3, SocketType::SPECTRAL, 0, ##__VA_ARGS__)
+  SOCKET_DEFINE( \
+      name, ui_name, default_value, SpectralColor, SocketType::SPECTRAL, 0, ##__VA_ARGS__)
 #define SOCKET_VECTOR(name, ui_name, default_value, ...) \
   SOCKET_DEFINE(name, ui_name, default_value, float3, SocketType::VECTOR, 0, ##__VA_ARGS__)
 #define SOCKET_POINT(name, ui_name, default_value, ...) \
@@ -310,7 +311,7 @@ struct NodeType {
   SOCKET_DEFINE(name, \
                 ui_name, \
                 default_value, \
-                float3, \
+                SpectralColor, \
                 SocketType::SPECTRAL, \
                 SocketType::LINKABLE, \
                 ##__VA_ARGS__)

--- a/intern/cycles/kernel/closure/alloc.h
+++ b/intern/cycles/kernel/closure/alloc.h
@@ -16,7 +16,10 @@
 
 CCL_NAMESPACE_BEGIN
 
-ccl_device ShaderClosure *closure_alloc(ShaderData *sd, int size, ClosureType type, float3 weight)
+ccl_device ShaderClosure *closure_alloc(ShaderData *sd,
+                                        int size,
+                                        ClosureType type,
+                                        SpectralColor weight)
 {
   kernel_assert(size <= sizeof(ShaderClosure));
 
@@ -55,7 +58,7 @@ ccl_device ccl_addr_space void *closure_alloc_extra(ShaderData *sd, int size)
   return (ccl_addr_space void *)(sd->closure + sd->num_closure + sd->num_closure_left);
 }
 
-ccl_device_inline ShaderClosure *bsdf_alloc(ShaderData *sd, int size, float3 weight)
+ccl_device_inline ShaderClosure *bsdf_alloc(ShaderData *sd, int size, SpectralColor weight)
 {
   ShaderClosure *sc = closure_alloc(sd, size, CLOSURE_NONE_ID, weight);
 
@@ -70,7 +73,7 @@ ccl_device_inline ShaderClosure *bsdf_alloc(ShaderData *sd, int size, float3 wei
 #ifdef __OSL__
 ccl_device_inline ShaderClosure *bsdf_alloc_osl(ShaderData *sd,
                                                 int size,
-                                                float3 weight,
+                                                SpectralColor weight,
                                                 void *data)
 {
   ShaderClosure *sc = closure_alloc(sd, size, CLOSURE_NONE_ID, weight);

--- a/intern/cycles/kernel/closure/bsdf.h
+++ b/intern/cycles/kernel/closure/bsdf.h
@@ -103,7 +103,7 @@ ccl_device_inline int bsdf_sample(KernelGlobals *kg,
                                   const ShaderClosure *sc,
                                   float randu,
                                   float randv,
-                                  float3 *eval,
+                                  SpectralColor *eval,
                                   float3 *omega_in,
                                   differential3 *domega_in,
                                   float *pdf)
@@ -463,14 +463,14 @@ ccl_device
 #else
 ccl_device_inline
 #endif
-    RGBColor
+    SpectralColor
     bsdf_eval(KernelGlobals *kg,
               ShaderData *sd,
               const ShaderClosure *sc,
               const float3 omega_in,
               float *pdf)
 {
-  RGBColor eval;
+  SpectralColor eval;
 
   if (dot(sd->Ng, omega_in) >= 0.0f) {
     switch (sc->type) {
@@ -562,7 +562,7 @@ ccl_device_inline
         break;
 #endif
       default:
-        eval = make_float3(0.0f, 0.0f, 0.0f);
+        eval = make_spectral_color(0.0f);
         break;
     }
     if (CLOSURE_IS_BSDF_DIFFUSE(sc->type)) {
@@ -653,7 +653,7 @@ ccl_device_inline
         break;
 #endif
       default:
-        eval = make_float3(0.0f, 0.0f, 0.0f);
+        eval = make_spectral_color(0.0f);
         break;
     }
     if (CLOSURE_IS_BSDF_DIFFUSE(sc->type)) {

--- a/intern/cycles/kernel/closure/bsdf_ashikhmin_shirley.h
+++ b/intern/cycles/kernel/closure/bsdf_ashikhmin_shirley.h
@@ -62,10 +62,10 @@ ccl_device_inline float bsdf_ashikhmin_shirley_roughness_to_exponent(float rough
   return 2.0f / (roughness * roughness) - 2.0f;
 }
 
-ccl_device_forceinline float3 bsdf_ashikhmin_shirley_eval_reflect(const ShaderClosure *sc,
-                                                                  const float3 I,
-                                                                  const float3 omega_in,
-                                                                  float *pdf)
+ccl_device_forceinline SpectralColor bsdf_ashikhmin_shirley_eval_reflect(const ShaderClosure *sc,
+                                                                         const float3 I,
+                                                                         const float3 omega_in,
+                                                                         float *pdf)
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
   float3 N = bsdf->N;
@@ -75,8 +75,9 @@ ccl_device_forceinline float3 bsdf_ashikhmin_shirley_eval_reflect(const ShaderCl
 
   float out = 0.0f;
 
-  if (fmaxf(bsdf->alpha_x, bsdf->alpha_y) <= 1e-4f)
-    return make_float3(0.0f, 0.0f, 0.0f);
+  if (fmaxf(bsdf->alpha_x, bsdf->alpha_y) <= 1e-4f) {
+    return make_spectral_color(0.0f);
+  }
 
   if (NdotI > 0.0f && NdotO > 0.0f) {
     NdotI = fmaxf(NdotI, 1e-6f);
@@ -126,15 +127,15 @@ ccl_device_forceinline float3 bsdf_ashikhmin_shirley_eval_reflect(const ShaderCl
     }
   }
 
-  return make_float3(out, out, out);
+  return make_spectral_color(out);
 }
 
-ccl_device float3 bsdf_ashikhmin_shirley_eval_transmit(const ShaderClosure *sc,
-                                                       const float3 I,
-                                                       const float3 omega_in,
-                                                       float *pdf)
+ccl_device SpectralColor bsdf_ashikhmin_shirley_eval_transmit(const ShaderClosure *sc,
+                                                              const float3 I,
+                                                              const float3 omega_in,
+                                                              float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device_inline void bsdf_ashikhmin_shirley_sample_first_quadrant(
@@ -153,7 +154,7 @@ ccl_device int bsdf_ashikhmin_shirley_sample(const ShaderClosure *sc,
                                              float3 dIdy,
                                              float randu,
                                              float randv,
-                                             float3 *eval,
+                                             SpectralColor *eval,
                                              float3 *omega_in,
                                              float3 *domega_in_dx,
                                              float3 *domega_in_dy,
@@ -230,7 +231,7 @@ ccl_device int bsdf_ashikhmin_shirley_sample(const ShaderClosure *sc,
     if (fmaxf(bsdf->alpha_x, bsdf->alpha_y) <= 1e-4f) {
       /* Some high number for MIS. */
       *pdf = 1e6f;
-      *eval = make_float3(1e6f, 1e6f, 1e6f);
+      *eval = make_spectral_color(1e6f);
       label = LABEL_REFLECT | LABEL_SINGULAR;
     }
     else {

--- a/intern/cycles/kernel/closure/bsdf_ashikhmin_velvet.h
+++ b/intern/cycles/kernel/closure/bsdf_ashikhmin_velvet.h
@@ -62,10 +62,10 @@ ccl_device bool bsdf_ashikhmin_velvet_merge(const ShaderClosure *a, const Shader
   return (isequal_float3(bsdf_a->N, bsdf_b->N)) && (bsdf_a->sigma == bsdf_b->sigma);
 }
 
-ccl_device float3 bsdf_ashikhmin_velvet_eval_reflect(const ShaderClosure *sc,
-                                                     const float3 I,
-                                                     const float3 omega_in,
-                                                     float *pdf)
+ccl_device SpectralColor bsdf_ashikhmin_velvet_eval_reflect(const ShaderClosure *sc,
+                                                            const float3 I,
+                                                            const float3 omega_in,
+                                                            float *pdf)
 {
   const VelvetBsdf *bsdf = (const VelvetBsdf *)sc;
   float m_invsigma2 = bsdf->invsigma2;
@@ -79,8 +79,9 @@ ccl_device float3 bsdf_ashikhmin_velvet_eval_reflect(const ShaderClosure *sc,
     float cosNH = dot(N, H);
     float cosHO = fabsf(dot(I, H));
 
-    if (!(fabsf(cosNH) < 1.0f - 1e-5f && cosHO > 1e-5f))
-      return make_float3(0.0f, 0.0f, 0.0f);
+    if (!(fabsf(cosNH) < 1.0f - 1e-5f && cosHO > 1e-5f)) {
+      return make_spectral_color(0.0f);
+    }
 
     float cosNHdivHO = cosNH / cosHO;
     cosNHdivHO = fmaxf(cosNHdivHO, 1e-5f);
@@ -98,18 +99,18 @@ ccl_device float3 bsdf_ashikhmin_velvet_eval_reflect(const ShaderClosure *sc,
     float out = 0.25f * (D * G) / cosNO;
 
     *pdf = 0.5f * M_1_PI_F;
-    return make_float3(out, out, out);
+    return make_spectral_color(out);
   }
 
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_ashikhmin_velvet_eval_transmit(const ShaderClosure *sc,
-                                                      const float3 I,
-                                                      const float3 omega_in,
-                                                      float *pdf)
+ccl_device SpectralColor bsdf_ashikhmin_velvet_eval_transmit(const ShaderClosure *sc,
+                                                             const float3 I,
+                                                             const float3 omega_in,
+                                                             float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_ashikhmin_velvet_sample(const ShaderClosure *sc,
@@ -119,7 +120,7 @@ ccl_device int bsdf_ashikhmin_velvet_sample(const ShaderClosure *sc,
                                             float3 dIdy,
                                             float randu,
                                             float randv,
-                                            float3 *eval,
+                                            SpectralColor *eval,
                                             float3 *omega_in,
                                             float3 *domega_in_dx,
                                             float3 *domega_in_dy,
@@ -157,7 +158,7 @@ ccl_device int bsdf_ashikhmin_velvet_sample(const ShaderClosure *sc,
 
       float power = 0.25f * (D * G) / cosNO;
 
-      *eval = make_float3(power, power, power);
+      *eval = make_spectral_color(power);
 
 #ifdef __RAY_DIFFERENTIALS__
       // TODO: find a better approximation for the retroreflective bounce

--- a/intern/cycles/kernel/closure/bsdf_diffuse.h
+++ b/intern/cycles/kernel/closure/bsdf_diffuse.h
@@ -57,25 +57,25 @@ ccl_device bool bsdf_diffuse_merge(const ShaderClosure *a, const ShaderClosure *
   return (isequal_float3(bsdf_a->N, bsdf_b->N));
 }
 
-ccl_device float3 bsdf_diffuse_eval_reflect(const ShaderClosure *sc,
-                                            const float3 I,
-                                            const float3 omega_in,
-                                            float *pdf)
+ccl_device SpectralColor bsdf_diffuse_eval_reflect(const ShaderClosure *sc,
+                                                   const float3 I,
+                                                   const float3 omega_in,
+                                                   float *pdf)
 {
   const DiffuseBsdf *bsdf = (const DiffuseBsdf *)sc;
   float3 N = bsdf->N;
 
   float cos_pi = fmaxf(dot(N, omega_in), 0.0f) * M_1_PI_F;
   *pdf = cos_pi;
-  return make_float3(cos_pi, cos_pi, cos_pi);
+  return make_spectral_color(cos_pi);
 }
 
-ccl_device float3 bsdf_diffuse_eval_transmit(const ShaderClosure *sc,
-                                             const float3 I,
-                                             const float3 omega_in,
-                                             float *pdf)
+ccl_device SpectralColor bsdf_diffuse_eval_transmit(const ShaderClosure *sc,
+                                                    const float3 I,
+                                                    const float3 omega_in,
+                                                    float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_diffuse_sample(const ShaderClosure *sc,
@@ -85,7 +85,7 @@ ccl_device int bsdf_diffuse_sample(const ShaderClosure *sc,
                                    float3 dIdy,
                                    float randu,
                                    float randv,
-                                   float3 *eval,
+                                   SpectralColor *eval,
                                    float3 *omega_in,
                                    float3 *domega_in_dx,
                                    float3 *domega_in_dy,
@@ -98,7 +98,7 @@ ccl_device int bsdf_diffuse_sample(const ShaderClosure *sc,
   sample_cos_hemisphere(N, randu, randv, omega_in, pdf);
 
   if (dot(Ng, *omega_in) > 0.0f) {
-    *eval = make_float3(*pdf, *pdf, *pdf);
+    *eval = make_spectral_color(*pdf);
 #ifdef __RAY_DIFFERENTIALS__
     // TODO: find a better approximation for the diffuse bounce
     *domega_in_dx = (2 * dot(N, dIdx)) * N - dIdx;
@@ -119,25 +119,25 @@ ccl_device int bsdf_translucent_setup(DiffuseBsdf *bsdf)
   return SD_BSDF | SD_BSDF_HAS_EVAL;
 }
 
-ccl_device float3 bsdf_translucent_eval_reflect(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_translucent_eval_reflect(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_translucent_eval_transmit(const ShaderClosure *sc,
-                                                 const float3 I,
-                                                 const float3 omega_in,
-                                                 float *pdf)
+ccl_device SpectralColor bsdf_translucent_eval_transmit(const ShaderClosure *sc,
+                                                        const float3 I,
+                                                        const float3 omega_in,
+                                                        float *pdf)
 {
   const DiffuseBsdf *bsdf = (const DiffuseBsdf *)sc;
   float3 N = bsdf->N;
 
   float cos_pi = fmaxf(-dot(N, omega_in), 0.0f) * M_1_PI_F;
   *pdf = cos_pi;
-  return make_float3(cos_pi, cos_pi, cos_pi);
+  return make_spectral_color(cos_pi);
 }
 
 ccl_device int bsdf_translucent_sample(const ShaderClosure *sc,
@@ -147,7 +147,7 @@ ccl_device int bsdf_translucent_sample(const ShaderClosure *sc,
                                        float3 dIdy,
                                        float randu,
                                        float randv,
-                                       float3 *eval,
+                                       SpectralColor *eval,
                                        float3 *omega_in,
                                        float3 *domega_in_dx,
                                        float3 *domega_in_dy,
@@ -160,7 +160,7 @@ ccl_device int bsdf_translucent_sample(const ShaderClosure *sc,
   // distribution over the hemisphere
   sample_cos_hemisphere(-N, randu, randv, omega_in, pdf);
   if (dot(Ng, *omega_in) < 0) {
-    *eval = make_float3(*pdf, *pdf, *pdf);
+    *eval = make_spectral_color(*pdf);
 #ifdef __RAY_DIFFERENTIALS__
     // TODO: find a better approximation for the diffuse bounce
     *domega_in_dx = -((2 * dot(N, dIdx)) * N - dIdx);

--- a/intern/cycles/kernel/closure/bsdf_diffuse_ramp.h
+++ b/intern/cycles/kernel/closure/bsdf_diffuse_ramp.h
@@ -45,18 +45,19 @@ typedef ccl_addr_space struct DiffuseRampBsdf {
 
 static_assert(sizeof(ShaderClosure) >= sizeof(DiffuseRampBsdf), "DiffuseRampBsdf is too large!");
 
-ccl_device float3 bsdf_diffuse_ramp_get_color(const float3 colors[8], float pos)
+ccl_device SpectralColor bsdf_diffuse_ramp_get_color(const float3 colors[8], float pos)
 {
-  int MAXCOLORS = 8;
+  //   int MAXCOLORS = 8;
 
-  float npos = pos * (float)(MAXCOLORS - 1);
-  int ipos = float_to_int(npos);
-  if (ipos < 0)
-    return colors[0];
-  if (ipos >= (MAXCOLORS - 1))
-    return colors[MAXCOLORS - 1];
-  float offset = npos - (float)ipos;
-  return colors[ipos] * (1.0f - offset) + colors[ipos + 1] * offset;
+  //   float npos = pos * (float)(MAXCOLORS - 1);
+  //   int ipos = float_to_int(npos);
+  //   if (ipos < 0)
+  //     return colors[0];
+  //   if (ipos >= (MAXCOLORS - 1))
+  //     return colors[MAXCOLORS - 1];
+  //   float offset = npos - (float)ipos;
+  //   return colors[ipos] * (1.0f - offset) + colors[ipos + 1] * offset;
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_diffuse_ramp_setup(DiffuseRampBsdf *bsdf)
@@ -69,10 +70,10 @@ ccl_device void bsdf_diffuse_ramp_blur(ShaderClosure *sc, float roughness)
 {
 }
 
-ccl_device float3 bsdf_diffuse_ramp_eval_reflect(const ShaderClosure *sc,
-                                                 const float3 I,
-                                                 const float3 omega_in,
-                                                 float *pdf)
+ccl_device SpectralColor bsdf_diffuse_ramp_eval_reflect(const ShaderClosure *sc,
+                                                        const float3 I,
+                                                        const float3 omega_in,
+                                                        float *pdf)
 {
   const DiffuseRampBsdf *bsdf = (const DiffuseRampBsdf *)sc;
   float3 N = bsdf->N;
@@ -97,7 +98,7 @@ ccl_device int bsdf_diffuse_ramp_sample(const ShaderClosure *sc,
                                         float3 dIdy,
                                         float randu,
                                         float randv,
-                                        float3 *eval,
+                                        SpectralColor *eval,
                                         float3 *omega_in,
                                         float3 *domega_in_dx,
                                         float3 *domega_in_dy,

--- a/intern/cycles/kernel/closure/bsdf_hair.h
+++ b/intern/cycles/kernel/closure/bsdf_hair.h
@@ -71,10 +71,10 @@ ccl_device bool bsdf_hair_merge(const ShaderClosure *a, const ShaderClosure *b)
          (bsdf_a->roughness2 == bsdf_b->roughness2) && (bsdf_a->offset == bsdf_b->offset);
 }
 
-ccl_device float3 bsdf_hair_reflection_eval_reflect(const ShaderClosure *sc,
-                                                    const float3 I,
-                                                    const float3 omega_in,
-                                                    float *pdf)
+ccl_device SpectralColor bsdf_hair_reflection_eval_reflect(const ShaderClosure *sc,
+                                                           const float3 I,
+                                                           const float3 omega_in,
+                                                           float *pdf)
 {
   const HairBsdf *bsdf = (const HairBsdf *)sc;
   float offset = bsdf->offset;
@@ -95,7 +95,7 @@ ccl_device float3 bsdf_hair_reflection_eval_reflect(const ShaderClosure *sc,
 
   if (M_PI_2_F - fabsf(theta_i) < 0.001f || cosphi_i < 0.0f) {
     *pdf = 0.0f;
-    return make_float3(*pdf, *pdf, *pdf);
+    return make_spectral_color(*pdf);
   }
 
   float roughness1_inv = 1.0f / roughness1;
@@ -115,29 +115,29 @@ ccl_device float3 bsdf_hair_reflection_eval_reflect(const ShaderClosure *sc,
                     (2 * (t * t + roughness1 * roughness1) * (a_R - b_R) * costheta_i);
   *pdf = phi_pdf * theta_pdf;
 
-  return make_float3(*pdf, *pdf, *pdf);
+  return make_spectral_color(*pdf);
 }
 
-ccl_device float3 bsdf_hair_transmission_eval_reflect(const ShaderClosure *sc,
-                                                      const float3 I,
-                                                      const float3 omega_in,
-                                                      float *pdf)
+ccl_device SpectralColor bsdf_hair_transmission_eval_reflect(const ShaderClosure *sc,
+                                                             const float3 I,
+                                                             const float3 omega_in,
+                                                             float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_hair_reflection_eval_transmit(const ShaderClosure *sc,
-                                                     const float3 I,
-                                                     const float3 omega_in,
-                                                     float *pdf)
+ccl_device SpectralColor bsdf_hair_reflection_eval_transmit(const ShaderClosure *sc,
+                                                            const float3 I,
+                                                            const float3 omega_in,
+                                                            float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_hair_transmission_eval_transmit(const ShaderClosure *sc,
-                                                       const float3 I,
-                                                       const float3 omega_in,
-                                                       float *pdf)
+ccl_device SpectralColor bsdf_hair_transmission_eval_transmit(const ShaderClosure *sc,
+                                                              const float3 I,
+                                                              const float3 omega_in,
+                                                              float *pdf)
 {
   const HairBsdf *bsdf = (const HairBsdf *)sc;
   float offset = bsdf->offset;
@@ -157,7 +157,7 @@ ccl_device float3 bsdf_hair_transmission_eval_transmit(const ShaderClosure *sc,
 
   if (M_PI_2_F - fabsf(theta_i) < 0.001f) {
     *pdf = 0.0f;
-    return make_float3(*pdf, *pdf, *pdf);
+    return make_spectral_color(*pdf);
   }
 
   float costheta_i = fast_cosf(theta_i);
@@ -177,7 +177,7 @@ ccl_device float3 bsdf_hair_transmission_eval_transmit(const ShaderClosure *sc,
   float phi_pdf = roughness2 / (c_TT * (p * p + roughness2 * roughness2));
 
   *pdf = phi_pdf * theta_pdf;
-  return make_float3(*pdf, *pdf, *pdf);
+  return make_spectral_color(*pdf);
 }
 
 ccl_device int bsdf_hair_reflection_sample(const ShaderClosure *sc,
@@ -187,7 +187,7 @@ ccl_device int bsdf_hair_reflection_sample(const ShaderClosure *sc,
                                            float3 dIdy,
                                            float randu,
                                            float randv,
-                                           float3 *eval,
+                                           SpectralColor *eval,
                                            float3 *omega_in,
                                            float3 *domega_in_dx,
                                            float3 *domega_in_dy,
@@ -236,7 +236,7 @@ ccl_device int bsdf_hair_reflection_sample(const ShaderClosure *sc,
   if (M_PI_2_F - fabsf(theta_i) < 0.001f)
     *pdf = 0.0f;
 
-  *eval = make_float3(*pdf, *pdf, *pdf);
+  *eval = make_spectral_color(*pdf);
 
   return LABEL_REFLECT | LABEL_GLOSSY;
 }
@@ -248,7 +248,7 @@ ccl_device int bsdf_hair_transmission_sample(const ShaderClosure *sc,
                                              float3 dIdy,
                                              float randu,
                                              float randv,
-                                             float3 *eval,
+                                             SpectralColor *eval,
                                              float3 *omega_in,
                                              float3 *domega_in_dx,
                                              float3 *domega_in_dy,
@@ -298,7 +298,7 @@ ccl_device int bsdf_hair_transmission_sample(const ShaderClosure *sc,
     *pdf = 0.0f;
   }
 
-  *eval = make_float3(*pdf, *pdf, *pdf);
+  *eval = make_spectral_color(*pdf);
 
   /* TODO(sergey): Should always be negative, but seems some precision issue
    * is involved here.

--- a/intern/cycles/kernel/closure/bsdf_microfacet_multi.h
+++ b/intern/cycles/kernel/closure/bsdf_microfacet_multi.h
@@ -103,29 +103,29 @@ ccl_device_forceinline float3 mf_sample_vndf(const float3 wi,
 
 /* Phase function for reflective materials. */
 ccl_device_forceinline float3 mf_sample_phase_glossy(const float3 wi,
-                                                     float3 *weight,
+                                                     SpectralColor *weight,
                                                      const float3 wm)
 {
   return -wi + 2.0f * wm * dot(wi, wm);
 }
 
-ccl_device_forceinline float3 mf_eval_phase_glossy(const float3 w,
-                                                   const float lambda,
-                                                   const float3 wo,
-                                                   const float2 alpha)
+ccl_device_forceinline SpectralColor mf_eval_phase_glossy(const float3 w,
+                                                          const float lambda,
+                                                          const float3 wo,
+                                                          const float2 alpha)
 {
   if (w.z > 0.9999f)
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
 
   const float3 wh = normalize(wo - w);
   if (wh.z < 0.0f)
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
 
   float pArea = (w.z < -0.9999f) ? 1.0f : lambda * w.z;
 
   const float dotW_WH = dot(-w, wh);
   if (dotW_WH < 0.0f)
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
 
   float phase = max(0.0f, dotW_WH) * 0.25f / max(pArea * dotW_WH, 1e-7f);
   if (alpha.x == alpha.y)
@@ -133,7 +133,7 @@ ccl_device_forceinline float3 mf_eval_phase_glossy(const float3 w,
   else
     phase *= D_ggx_aniso(wh, alpha);
 
-  return make_float3(phase, phase, phase);
+  return make_spectral_color(phase);
 }
 
 /* Phase function for dielectric transmissive materials, including both reflection and refraction
@@ -153,22 +153,24 @@ ccl_device_forceinline float3 mf_sample_phase_glass(
   return normalize(wm * (cosI * inv_eta + cosT) - wi * inv_eta);
 }
 
-ccl_device_forceinline float3 mf_eval_phase_glass(const float3 w,
-                                                  const float lambda,
-                                                  const float3 wo,
-                                                  const bool wo_outside,
-                                                  const float2 alpha,
-                                                  const float eta)
+ccl_device_forceinline SpectralColor mf_eval_phase_glass(const float3 w,
+                                                         const float lambda,
+                                                         const float3 wo,
+                                                         const bool wo_outside,
+                                                         const float2 alpha,
+                                                         const float eta)
 {
-  if (w.z > 0.9999f)
-    return make_float3(0.0f, 0.0f, 0.0f);
+  if (w.z > 0.9999f) {
+    return make_spectral_color(0.0f);
+  }
 
   float pArea = (w.z < -0.9999f) ? 1.0f : lambda * w.z;
   float v;
   if (wo_outside) {
     const float3 wh = normalize(wo - w);
-    if (wh.z < 0.0f)
-      return make_float3(0.0f, 0.0f, 0.0f);
+    if (wh.z < 0.0f) {
+      return make_spectral_color(0.0f);
+    }
 
     const float dotW_WH = dot(-w, wh);
     v = fresnel_dielectric_cos(dotW_WH, eta) * max(0.0f, dotW_WH) * D_ggx(wh, alpha.x) * 0.25f /
@@ -179,15 +181,16 @@ ccl_device_forceinline float3 mf_eval_phase_glass(const float3 w,
     if (wh.z < 0.0f)
       wh = -wh;
     const float dotW_WH = dot(-w, wh), dotWO_WH = dot(wo, wh);
-    if (dotW_WH < 0.0f)
-      return make_float3(0.0f, 0.0f, 0.0f);
+    if (dotW_WH < 0.0f) {
+      return make_spectral_color(0.0f);
+    }
 
     float temp = dotW_WH + eta * dotWO_WH;
     v = (1.0f - fresnel_dielectric_cos(dotW_WH, eta)) * max(0.0f, dotW_WH) * max(0.0f, -dotWO_WH) *
         D_ggx(wh, alpha.x) / (pArea * temp * temp);
   }
 
-  return make_float3(v, v, v);
+  return make_spectral_color(v);
 }
 
 /* === Utility functions for the random walks === */
@@ -378,8 +381,8 @@ ccl_device int bsdf_microfacet_multi_ggx_common_setup(MicrofacetBsdf *bsdf)
 {
   bsdf->alpha_x = clamp(bsdf->alpha_x, 1e-4f, 1.0f);
   bsdf->alpha_y = clamp(bsdf->alpha_y, 1e-4f, 1.0f);
-  bsdf->extra->color = saturate3(bsdf->extra->color);
-  bsdf->extra->cspec0 = saturate3(bsdf->extra->cspec0);
+  bsdf->extra->color = saturate(bsdf->extra->color);
+  bsdf->extra->cspec0 = saturate(bsdf->extra->cspec0);
 
   return SD_BSDF | SD_BSDF_HAS_EVAL | SD_BSDF_NEEDS_LCG;
 }
@@ -436,26 +439,26 @@ ccl_device int bsdf_microfacet_multi_ggx_refraction_setup(MicrofacetBsdf *bsdf)
   return bsdf_microfacet_multi_ggx_common_setup(bsdf);
 }
 
-ccl_device float3 bsdf_microfacet_multi_ggx_eval_transmit(const ShaderClosure *sc,
-                                                          const float3 I,
-                                                          const float3 omega_in,
-                                                          float *pdf,
-                                                          ccl_addr_space uint *lcg_state)
+ccl_device SpectralColor bsdf_microfacet_multi_ggx_eval_transmit(const ShaderClosure *sc,
+                                                                 const float3 I,
+                                                                 const float3 omega_in,
+                                                                 float *pdf,
+                                                                 ccl_addr_space uint *lcg_state)
 {
   *pdf = 0.0f;
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_microfacet_multi_ggx_eval_reflect(const ShaderClosure *sc,
-                                                         const float3 I,
-                                                         const float3 omega_in,
-                                                         float *pdf,
-                                                         ccl_addr_space uint *lcg_state)
+ccl_device SpectralColor bsdf_microfacet_multi_ggx_eval_reflect(const ShaderClosure *sc,
+                                                                const float3 I,
+                                                                const float3 omega_in,
+                                                                float *pdf,
+                                                                ccl_addr_space uint *lcg_state)
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
 
   if (bsdf->alpha_x * bsdf->alpha_y < 1e-7f) {
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 
   bool use_fresnel = (bsdf->type == CLOSURE_BSDF_MICROFACET_MULTI_GGX_FRESNEL_ID);
@@ -495,7 +498,7 @@ ccl_device int bsdf_microfacet_multi_ggx_sample(KernelGlobals *kg,
                                                 float3 dIdy,
                                                 float randu,
                                                 float randv,
-                                                float3 *eval,
+                                                SpectralColor *eval,
                                                 float3 *omega_in,
                                                 float3 *domega_in_dx,
                                                 float3 *domega_in_dy,
@@ -510,7 +513,7 @@ ccl_device int bsdf_microfacet_multi_ggx_sample(KernelGlobals *kg,
   if (bsdf->alpha_x * bsdf->alpha_y < 1e-7f) {
     *omega_in = 2 * dot(Z, I) * Z - I;
     *pdf = 1e6f;
-    *eval = make_float3(1e6f, 1e6f, 1e6f);
+    *eval = make_spectral_color(1e6f);
 #ifdef __RAY_DIFFERENTIALS__
     *domega_in_dx = (2 * dot(Z, dIdx)) * Z - dIdx;
     *domega_in_dy = (2 * dot(Z, dIdy)) * Z - dIdy;
@@ -560,7 +563,7 @@ ccl_device int bsdf_microfacet_multi_ggx_glass_setup(MicrofacetBsdf *bsdf)
   bsdf->alpha_x = clamp(bsdf->alpha_x, 1e-4f, 1.0f);
   bsdf->alpha_y = bsdf->alpha_x;
   bsdf->ior = max(0.0f, bsdf->ior);
-  bsdf->extra->color = saturate3(bsdf->extra->color);
+  bsdf->extra->color = saturate(bsdf->extra->color);
 
   bsdf->type = CLOSURE_BSDF_MICROFACET_MULTI_GGX_GLASS_ID;
 
@@ -573,8 +576,8 @@ ccl_device int bsdf_microfacet_multi_ggx_glass_fresnel_setup(MicrofacetBsdf *bsd
   bsdf->alpha_x = clamp(bsdf->alpha_x, 1e-4f, 1.0f);
   bsdf->alpha_y = bsdf->alpha_x;
   bsdf->ior = max(0.0f, bsdf->ior);
-  bsdf->extra->color = saturate3(bsdf->extra->color);
-  bsdf->extra->cspec0 = saturate3(bsdf->extra->cspec0);
+  bsdf->extra->color = saturate(bsdf->extra->color);
+  bsdf->extra->cspec0 = saturate(bsdf->extra->cspec0);
 
   bsdf->type = CLOSURE_BSDF_MICROFACET_MULTI_GGX_GLASS_FRESNEL_ID;
 
@@ -583,16 +586,17 @@ ccl_device int bsdf_microfacet_multi_ggx_glass_fresnel_setup(MicrofacetBsdf *bsd
   return SD_BSDF | SD_BSDF_HAS_EVAL | SD_BSDF_NEEDS_LCG;
 }
 
-ccl_device float3 bsdf_microfacet_multi_ggx_glass_eval_transmit(const ShaderClosure *sc,
-                                                                const float3 I,
-                                                                const float3 omega_in,
-                                                                float *pdf,
-                                                                ccl_addr_space uint *lcg_state)
+ccl_device SpectralColor
+bsdf_microfacet_multi_ggx_glass_eval_transmit(const ShaderClosure *sc,
+                                              const float3 I,
+                                              const float3 omega_in,
+                                              float *pdf,
+                                              ccl_addr_space uint *lcg_state)
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
 
   if (bsdf->alpha_x * bsdf->alpha_y < 1e-7f) {
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 
   float3 X, Y, Z;
@@ -615,16 +619,17 @@ ccl_device float3 bsdf_microfacet_multi_ggx_glass_eval_transmit(const ShaderClos
                        bsdf->extra->color);
 }
 
-ccl_device float3 bsdf_microfacet_multi_ggx_glass_eval_reflect(const ShaderClosure *sc,
-                                                               const float3 I,
-                                                               const float3 omega_in,
-                                                               float *pdf,
-                                                               ccl_addr_space uint *lcg_state)
+ccl_device SpectralColor
+bsdf_microfacet_multi_ggx_glass_eval_reflect(const ShaderClosure *sc,
+                                             const float3 I,
+                                             const float3 omega_in,
+                                             float *pdf,
+                                             ccl_addr_space uint *lcg_state)
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
 
   if (bsdf->alpha_x * bsdf->alpha_y < 1e-7f) {
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 
   bool use_fresnel = (bsdf->type == CLOSURE_BSDF_MICROFACET_MULTI_GGX_GLASS_FRESNEL_ID);
@@ -657,7 +662,7 @@ ccl_device int bsdf_microfacet_multi_ggx_glass_sample(KernelGlobals *kg,
                                                       float3 dIdy,
                                                       float randu,
                                                       float randv,
-                                                      float3 *eval,
+                                                      SpectralColor *eval,
                                                       float3 *omega_in,
                                                       float3 *domega_in_dx,
                                                       float3 *domega_in_dy,
@@ -691,7 +696,7 @@ ccl_device int bsdf_microfacet_multi_ggx_glass_sample(KernelGlobals *kg,
                                        &inside);
 
     *pdf = 1e6f;
-    *eval = make_float3(1e6f, 1e6f, 1e6f);
+    *eval = make_spectral_color(1e6f);
     if (randu < fresnel) {
       *omega_in = R;
 #ifdef __RAY_DIFFERENTIALS__

--- a/intern/cycles/kernel/closure/bsdf_oren_nayar.h
+++ b/intern/cycles/kernel/closure/bsdf_oren_nayar.h
@@ -29,10 +29,10 @@ typedef ccl_addr_space struct OrenNayarBsdf {
 
 static_assert(sizeof(ShaderClosure) >= sizeof(OrenNayarBsdf), "OrenNayarBsdf is too large!");
 
-ccl_device float3 bsdf_oren_nayar_get_intensity(const ShaderClosure *sc,
-                                                float3 n,
-                                                float3 v,
-                                                float3 l)
+ccl_device SpectralColor bsdf_oren_nayar_get_intensity(const ShaderClosure *sc,
+                                                       float3 n,
+                                                       float3 v,
+                                                       float3 l)
 {
   const OrenNayarBsdf *bsdf = (const OrenNayarBsdf *)sc;
   float nl = max(dot(n, l), 0.0f);
@@ -42,7 +42,7 @@ ccl_device float3 bsdf_oren_nayar_get_intensity(const ShaderClosure *sc,
   if (t > 0.0f)
     t /= max(nl, nv) + FLT_MIN;
   float is = nl * (bsdf->a + bsdf->b * t);
-  return make_float3(is, is, is);
+  return make_spectral_color(is);
 }
 
 ccl_device int bsdf_oren_nayar_setup(OrenNayarBsdf *bsdf)
@@ -69,10 +69,10 @@ ccl_device bool bsdf_oren_nayar_merge(const ShaderClosure *a, const ShaderClosur
   return (isequal_float3(bsdf_a->N, bsdf_b->N)) && (bsdf_a->roughness == bsdf_b->roughness);
 }
 
-ccl_device float3 bsdf_oren_nayar_eval_reflect(const ShaderClosure *sc,
-                                               const float3 I,
-                                               const float3 omega_in,
-                                               float *pdf)
+ccl_device SpectralColor bsdf_oren_nayar_eval_reflect(const ShaderClosure *sc,
+                                                      const float3 I,
+                                                      const float3 omega_in,
+                                                      float *pdf)
 {
   const OrenNayarBsdf *bsdf = (const OrenNayarBsdf *)sc;
   if (dot(bsdf->N, omega_in) > 0.0f) {
@@ -81,16 +81,16 @@ ccl_device float3 bsdf_oren_nayar_eval_reflect(const ShaderClosure *sc,
   }
   else {
     *pdf = 0.0f;
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 }
 
-ccl_device float3 bsdf_oren_nayar_eval_transmit(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_oren_nayar_eval_transmit(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_oren_nayar_sample(const ShaderClosure *sc,
@@ -100,7 +100,7 @@ ccl_device int bsdf_oren_nayar_sample(const ShaderClosure *sc,
                                       float3 dIdy,
                                       float randu,
                                       float randv,
-                                      float3 *eval,
+                                      SpectralColor *eval,
                                       float3 *omega_in,
                                       float3 *domega_in_dx,
                                       float3 *domega_in_dy,
@@ -120,7 +120,7 @@ ccl_device int bsdf_oren_nayar_sample(const ShaderClosure *sc,
   }
   else {
     *pdf = 0.0f;
-    *eval = make_float3(0.0f, 0.0f, 0.0f);
+    *eval = make_spectral_color(0.0f);
   }
 
   return LABEL_REFLECT | LABEL_DIFFUSE;

--- a/intern/cycles/kernel/closure/bsdf_phong_ramp.h
+++ b/intern/cycles/kernel/closure/bsdf_phong_ramp.h
@@ -46,18 +46,19 @@ typedef ccl_addr_space struct PhongRampBsdf {
 
 static_assert(sizeof(ShaderClosure) >= sizeof(PhongRampBsdf), "PhongRampBsdf is too large!");
 
-ccl_device float3 bsdf_phong_ramp_get_color(const float3 colors[8], float pos)
+ccl_device SpectralColor bsdf_phong_ramp_get_color(const float3 colors[8], float pos)
 {
-  int MAXCOLORS = 8;
+  //   int MAXCOLORS = 8;
 
-  float npos = pos * (float)(MAXCOLORS - 1);
-  int ipos = float_to_int(npos);
-  if (ipos < 0)
-    return colors[0];
-  if (ipos >= (MAXCOLORS - 1))
-    return colors[MAXCOLORS - 1];
-  float offset = npos - (float)ipos;
-  return colors[ipos] * (1.0f - offset) + colors[ipos + 1] * offset;
+  //   float npos = pos * (float)(MAXCOLORS - 1);
+  //   int ipos = float_to_int(npos);
+  //   if (ipos < 0)
+  //     return colors[0];
+  //   if (ipos >= (MAXCOLORS - 1))
+  //     return colors[MAXCOLORS - 1];
+  //   float offset = npos - (float)ipos;
+  //   return colors[ipos] * (1.0f - offset) + colors[ipos + 1] * offset;
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_phong_ramp_setup(PhongRampBsdf *bsdf)
@@ -67,10 +68,10 @@ ccl_device int bsdf_phong_ramp_setup(PhongRampBsdf *bsdf)
   return SD_BSDF | SD_BSDF_HAS_EVAL;
 }
 
-ccl_device float3 bsdf_phong_ramp_eval_reflect(const ShaderClosure *sc,
-                                               const float3 I,
-                                               const float3 omega_in,
-                                               float *pdf)
+ccl_device SpectralColor bsdf_phong_ramp_eval_reflect(const ShaderClosure *sc,
+                                                      const float3 I,
+                                                      const float3 omega_in,
+                                                      float *pdf)
 {
   const PhongRampBsdf *bsdf = (const PhongRampBsdf *)sc;
   float m_exponent = bsdf->exponent;
@@ -90,7 +91,7 @@ ccl_device float3 bsdf_phong_ramp_eval_reflect(const ShaderClosure *sc,
     }
   }
 
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device float3 bsdf_phong_ramp_eval_transmit(const ShaderClosure *sc,
@@ -108,7 +109,7 @@ ccl_device int bsdf_phong_ramp_sample(const ShaderClosure *sc,
                                       float3 dIdy,
                                       float randu,
                                       float randv,
-                                      float3 *eval,
+                                      SpectralColor *eval,
                                       float3 *omega_in,
                                       float3 *domega_in_dx,
                                       float3 *domega_in_dy,

--- a/intern/cycles/kernel/closure/bsdf_principled_diffuse.h
+++ b/intern/cycles/kernel/closure/bsdf_principled_diffuse.h
@@ -33,7 +33,7 @@ typedef ccl_addr_space struct PrincipledDiffuseBsdf {
 static_assert(sizeof(ShaderClosure) >= sizeof(PrincipledDiffuseBsdf),
               "PrincipledDiffuseBsdf is too large!");
 
-ccl_device float3 calculate_principled_diffuse_brdf(
+ccl_device SpectralColor calculate_principled_diffuse_brdf(
     const PrincipledDiffuseBsdf *bsdf, float3 N, float3 V, float3 L, float3 H, float *pdf)
 {
   float NdotL = max(dot(N, L), 0.0f);
@@ -41,7 +41,7 @@ ccl_device float3 calculate_principled_diffuse_brdf(
 
   if (NdotL < 0 || NdotV < 0) {
     *pdf = 0.0f;
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 
   float LdotH = dot(L, H);
@@ -52,7 +52,7 @@ ccl_device float3 calculate_principled_diffuse_brdf(
 
   float value = M_1_PI_F * NdotL * Fd;
 
-  return make_float3(value, value, value);
+  return make_spectral_color(value);
 }
 
 ccl_device int bsdf_principled_diffuse_setup(PrincipledDiffuseBsdf *bsdf)
@@ -69,10 +69,10 @@ ccl_device bool bsdf_principled_diffuse_merge(const ShaderClosure *a, const Shad
   return (isequal_float3(bsdf_a->N, bsdf_b->N) && bsdf_a->roughness == bsdf_b->roughness);
 }
 
-ccl_device float3 bsdf_principled_diffuse_eval_reflect(const ShaderClosure *sc,
-                                                       const float3 I,
-                                                       const float3 omega_in,
-                                                       float *pdf)
+ccl_device SpectralColor bsdf_principled_diffuse_eval_reflect(const ShaderClosure *sc,
+                                                              const float3 I,
+                                                              const float3 omega_in,
+                                                              float *pdf)
 {
   const PrincipledDiffuseBsdf *bsdf = (const PrincipledDiffuseBsdf *)sc;
 
@@ -87,16 +87,16 @@ ccl_device float3 bsdf_principled_diffuse_eval_reflect(const ShaderClosure *sc,
   }
   else {
     *pdf = 0.0f;
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 }
 
-ccl_device float3 bsdf_principled_diffuse_eval_transmit(const ShaderClosure *sc,
-                                                        const float3 I,
-                                                        const float3 omega_in,
-                                                        float *pdf)
+ccl_device SpectralColor bsdf_principled_diffuse_eval_transmit(const ShaderClosure *sc,
+                                                               const float3 I,
+                                                               const float3 omega_in,
+                                                               float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_principled_diffuse_sample(const ShaderClosure *sc,
@@ -106,7 +106,7 @@ ccl_device int bsdf_principled_diffuse_sample(const ShaderClosure *sc,
                                               float3 dIdy,
                                               float randu,
                                               float randv,
-                                              float3 *eval,
+                                              SpectralColor *eval,
                                               float3 *omega_in,
                                               float3 *domega_in_dx,
                                               float3 *domega_in_dy,

--- a/intern/cycles/kernel/closure/bsdf_principled_sheen.h
+++ b/intern/cycles/kernel/closure/bsdf_principled_sheen.h
@@ -44,7 +44,7 @@ ccl_device_inline float calculate_avg_principled_sheen_brdf(float3 N, float3 I)
   return schlick_fresnel(NdotI) * NdotI;
 }
 
-ccl_device float3
+ccl_device SpectralColor
 calculate_principled_sheen_brdf(float3 N, float3 V, float3 L, float3 H, float *pdf)
 {
   float NdotL = dot(N, L);
@@ -52,14 +52,14 @@ calculate_principled_sheen_brdf(float3 N, float3 V, float3 L, float3 H, float *p
 
   if (NdotL < 0 || NdotV < 0) {
     *pdf = 0.0f;
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 
   float LdotH = dot(L, H);
 
   float value = schlick_fresnel(LdotH) * NdotL;
 
-  return make_float3(value, value, value);
+  return make_spectral_color(value);
 }
 
 ccl_device int bsdf_principled_sheen_setup(const ShaderData *sd, PrincipledSheenBsdf *bsdf)
@@ -70,10 +70,10 @@ ccl_device int bsdf_principled_sheen_setup(const ShaderData *sd, PrincipledSheen
   return SD_BSDF | SD_BSDF_HAS_EVAL;
 }
 
-ccl_device float3 bsdf_principled_sheen_eval_reflect(const ShaderClosure *sc,
-                                                     const float3 I,
-                                                     const float3 omega_in,
-                                                     float *pdf)
+ccl_device SpectralColor bsdf_principled_sheen_eval_reflect(const ShaderClosure *sc,
+                                                            const float3 I,
+                                                            const float3 omega_in,
+                                                            float *pdf)
 {
   const PrincipledSheenBsdf *bsdf = (const PrincipledSheenBsdf *)sc;
 
@@ -88,16 +88,16 @@ ccl_device float3 bsdf_principled_sheen_eval_reflect(const ShaderClosure *sc,
   }
   else {
     *pdf = 0.0f;
-    return make_float3(0.0f, 0.0f, 0.0f);
+    return make_spectral_color(0.0f);
   }
 }
 
-ccl_device float3 bsdf_principled_sheen_eval_transmit(const ShaderClosure *sc,
-                                                      const float3 I,
-                                                      const float3 omega_in,
-                                                      float *pdf)
+ccl_device SpectralColor bsdf_principled_sheen_eval_transmit(const ShaderClosure *sc,
+                                                             const float3 I,
+                                                             const float3 omega_in,
+                                                             float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_principled_sheen_sample(const ShaderClosure *sc,
@@ -107,7 +107,7 @@ ccl_device int bsdf_principled_sheen_sample(const ShaderClosure *sc,
                                             float3 dIdy,
                                             float randu,
                                             float randv,
-                                            float3 *eval,
+                                            SpectralColor *eval,
                                             float3 *omega_in,
                                             float3 *domega_in_dx,
                                             float3 *domega_in_dy,

--- a/intern/cycles/kernel/closure/bsdf_reflection.h
+++ b/intern/cycles/kernel/closure/bsdf_reflection.h
@@ -43,20 +43,20 @@ ccl_device int bsdf_reflection_setup(MicrofacetBsdf *bsdf)
   return SD_BSDF;
 }
 
-ccl_device float3 bsdf_reflection_eval_reflect(const ShaderClosure *sc,
-                                               const float3 I,
-                                               const float3 omega_in,
-                                               float *pdf)
+ccl_device SpectralColor bsdf_reflection_eval_reflect(const ShaderClosure *sc,
+                                                      const float3 I,
+                                                      const float3 omega_in,
+                                                      float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_reflection_eval_transmit(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_reflection_eval_transmit(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_reflection_sample(const ShaderClosure *sc,
@@ -66,7 +66,7 @@ ccl_device int bsdf_reflection_sample(const ShaderClosure *sc,
                                       float3 dIdy,
                                       float randu,
                                       float randv,
-                                      float3 *eval,
+                                      SpectralColor *eval,
                                       float3 *omega_in,
                                       float3 *domega_in_dx,
                                       float3 *domega_in_dy,
@@ -86,7 +86,7 @@ ccl_device int bsdf_reflection_sample(const ShaderClosure *sc,
 #endif
       /* Some high number for MIS. */
       *pdf = 1e6f;
-      *eval = make_float3(1e6f, 1e6f, 1e6f);
+      *eval = make_spectral_color(1e6f);
     }
   }
   return LABEL_REFLECT | LABEL_SINGULAR;

--- a/intern/cycles/kernel/closure/bsdf_refraction.h
+++ b/intern/cycles/kernel/closure/bsdf_refraction.h
@@ -43,20 +43,20 @@ ccl_device int bsdf_refraction_setup(MicrofacetBsdf *bsdf)
   return SD_BSDF;
 }
 
-ccl_device float3 bsdf_refraction_eval_reflect(const ShaderClosure *sc,
-                                               const float3 I,
-                                               const float3 omega_in,
-                                               float *pdf)
+ccl_device SpectralColor bsdf_refraction_eval_reflect(const ShaderClosure *sc,
+                                                      const float3 I,
+                                                      const float3 omega_in,
+                                                      float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_refraction_eval_transmit(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_refraction_eval_transmit(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_refraction_sample(const ShaderClosure *sc,
@@ -66,7 +66,7 @@ ccl_device int bsdf_refraction_sample(const ShaderClosure *sc,
                                       float3 dIdy,
                                       float randu,
                                       float randv,
-                                      float3 *eval,
+                                      SpectralColor *eval,
                                       float3 *omega_in,
                                       float3 *domega_in_dx,
                                       float3 *domega_in_dy,
@@ -100,7 +100,7 @@ ccl_device int bsdf_refraction_sample(const ShaderClosure *sc,
   if (!inside && fresnel != 1.0f) {
     /* Some high number for MIS. */
     *pdf = 1e6f;
-    *eval = make_float3(1e6f, 1e6f, 1e6f);
+    *eval = make_spectral_color(1e6f);
     *omega_in = T;
 #ifdef __RAY_DIFFERENTIALS__
     *domega_in_dx = dTdx;

--- a/intern/cycles/kernel/closure/bsdf_toon.h
+++ b/intern/cycles/kernel/closure/bsdf_toon.h
@@ -64,7 +64,7 @@ ccl_device bool bsdf_toon_merge(const ShaderClosure *a, const ShaderClosure *b)
          (bsdf_a->smooth == bsdf_b->smooth);
 }
 
-ccl_device float3 bsdf_toon_get_intensity(float max_angle, float smooth, float angle)
+ccl_device SpectralColor bsdf_toon_get_intensity(float max_angle, float smooth, float angle)
 {
   float is;
 
@@ -75,7 +75,7 @@ ccl_device float3 bsdf_toon_get_intensity(float max_angle, float smooth, float a
   else
     is = 0.0f;
 
-  return make_float3(is, is, is);
+  return make_spectral_color(is);
 }
 
 ccl_device float bsdf_toon_get_sample_angle(float max_angle, float smooth)
@@ -83,17 +83,17 @@ ccl_device float bsdf_toon_get_sample_angle(float max_angle, float smooth)
   return fminf(max_angle + smooth, M_PI_2_F);
 }
 
-ccl_device float3 bsdf_diffuse_toon_eval_reflect(const ShaderClosure *sc,
-                                                 const float3 I,
-                                                 const float3 omega_in,
-                                                 float *pdf)
+ccl_device SpectralColor bsdf_diffuse_toon_eval_reflect(const ShaderClosure *sc,
+                                                        const float3 I,
+                                                        const float3 omega_in,
+                                                        float *pdf)
 {
   const ToonBsdf *bsdf = (const ToonBsdf *)sc;
   float max_angle = bsdf->size * M_PI_2_F;
   float smooth = bsdf->smooth * M_PI_2_F;
   float angle = safe_acosf(fmaxf(dot(bsdf->N, omega_in), 0.0f));
 
-  float3 eval = bsdf_toon_get_intensity(max_angle, smooth, angle);
+  SpectralColor eval = bsdf_toon_get_intensity(max_angle, smooth, angle);
 
   if (eval.x > 0.0f) {
     float sample_angle = bsdf_toon_get_sample_angle(max_angle, smooth);
@@ -102,15 +102,15 @@ ccl_device float3 bsdf_diffuse_toon_eval_reflect(const ShaderClosure *sc,
     return *pdf * eval;
   }
 
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_diffuse_toon_eval_transmit(const ShaderClosure *sc,
-                                                  const float3 I,
-                                                  const float3 omega_in,
-                                                  float *pdf)
+ccl_device SpectralColor bsdf_diffuse_toon_eval_transmit(const ShaderClosure *sc,
+                                                         const float3 I,
+                                                         const float3 omega_in,
+                                                         float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_diffuse_toon_sample(const ShaderClosure *sc,
@@ -120,7 +120,7 @@ ccl_device int bsdf_diffuse_toon_sample(const ShaderClosure *sc,
                                         float3 dIdy,
                                         float randu,
                                         float randv,
-                                        float3 *eval,
+                                        SpectralColor *eval,
                                         float3 *omega_in,
                                         float3 *domega_in_dx,
                                         float3 *domega_in_dy,
@@ -162,10 +162,10 @@ ccl_device int bsdf_glossy_toon_setup(ToonBsdf *bsdf)
   return SD_BSDF | SD_BSDF_HAS_EVAL;
 }
 
-ccl_device float3 bsdf_glossy_toon_eval_reflect(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_glossy_toon_eval_reflect(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
   const ToonBsdf *bsdf = (const ToonBsdf *)sc;
   float max_angle = bsdf->size * M_PI_2_F;
@@ -180,22 +180,22 @@ ccl_device float3 bsdf_glossy_toon_eval_reflect(const ShaderClosure *sc,
 
     float angle = safe_acosf(fmaxf(cosRI, 0.0f));
 
-    float3 eval = bsdf_toon_get_intensity(max_angle, smooth, angle);
+    SpectralColor eval = bsdf_toon_get_intensity(max_angle, smooth, angle);
     float sample_angle = bsdf_toon_get_sample_angle(max_angle, smooth);
 
     *pdf = 0.5f * M_1_PI_F / (1.0f - cosf(sample_angle));
     return *pdf * eval;
   }
 
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_glossy_toon_eval_transmit(const ShaderClosure *sc,
-                                                 const float3 I,
-                                                 const float3 omega_in,
-                                                 float *pdf)
+ccl_device SpectralColor bsdf_glossy_toon_eval_transmit(const ShaderClosure *sc,
+                                                        const float3 I,
+                                                        const float3 omega_in,
+                                                        float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_glossy_toon_sample(const ShaderClosure *sc,
@@ -205,7 +205,7 @@ ccl_device int bsdf_glossy_toon_sample(const ShaderClosure *sc,
                                        float3 dIdy,
                                        float randu,
                                        float randv,
-                                       float3 *eval,
+                                       SpectralColor *eval,
                                        float3 *omega_in,
                                        float3 *domega_in_dx,
                                        float3 *domega_in_dy,

--- a/intern/cycles/kernel/closure/bsdf_transparent.h
+++ b/intern/cycles/kernel/closure/bsdf_transparent.h
@@ -35,7 +35,7 @@
 
 CCL_NAMESPACE_BEGIN
 
-ccl_device void bsdf_transparent_setup(ShaderData *sd, const float3 weight, int path_flag)
+ccl_device void bsdf_transparent_setup(ShaderData *sd, const SpectralColor weight, int path_flag)
 {
   /* Check cutoff weight. */
   float sample_weight = fabsf(average(weight));
@@ -82,20 +82,20 @@ ccl_device void bsdf_transparent_setup(ShaderData *sd, const float3 weight, int 
   }
 }
 
-ccl_device float3 bsdf_transparent_eval_reflect(const ShaderClosure *sc,
-                                                const float3 I,
-                                                const float3 omega_in,
-                                                float *pdf)
+ccl_device SpectralColor bsdf_transparent_eval_reflect(const ShaderClosure *sc,
+                                                       const float3 I,
+                                                       const float3 omega_in,
+                                                       float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
-ccl_device float3 bsdf_transparent_eval_transmit(const ShaderClosure *sc,
-                                                 const float3 I,
-                                                 const float3 omega_in,
-                                                 float *pdf)
+ccl_device SpectralColor bsdf_transparent_eval_transmit(const ShaderClosure *sc,
+                                                        const float3 I,
+                                                        const float3 omega_in,
+                                                        float *pdf)
 {
-  return make_float3(0.0f, 0.0f, 0.0f);
+  return make_spectral_color(0.0f);
 }
 
 ccl_device int bsdf_transparent_sample(const ShaderClosure *sc,
@@ -105,7 +105,7 @@ ccl_device int bsdf_transparent_sample(const ShaderClosure *sc,
                                        float3 dIdy,
                                        float randu,
                                        float randv,
-                                       float3 *eval,
+                                       SpectralColor *eval,
                                        float3 *omega_in,
                                        float3 *domega_in_dx,
                                        float3 *domega_in_dy,
@@ -118,7 +118,7 @@ ccl_device int bsdf_transparent_sample(const ShaderClosure *sc,
   *domega_in_dy = -dIdy;
 #endif
   *pdf = 1;
-  *eval = make_float3(1, 1, 1);
+  *eval = make_spectral_color(1.0f);
   return LABEL_TRANSMIT | LABEL_TRANSPARENT;
 }
 

--- a/intern/cycles/kernel/closure/bsdf_util.h
+++ b/intern/cycles/kernel/closure/bsdf_util.h
@@ -135,8 +135,8 @@ ccl_device float schlick_fresnel(float u)
 }
 
 /* Calculate the fresnel color which is a blend between white and the F0 color (cspec0) */
-ccl_device_forceinline float3
-interpolate_fresnel_color(float3 L, float3 H, float ior, float F0, float3 cspec0)
+ccl_device_forceinline SpectralColor
+interpolate_fresnel_color(float3 L, float3 H, float ior, float F0, SpectralColor cspec0)
 {
   /* Calculate the fresnel interpolation factor
    * The value from fresnel_dielectric_cos(...) has to be normalized because
@@ -146,7 +146,7 @@ interpolate_fresnel_color(float3 L, float3 H, float ior, float F0, float3 cspec0
   float FH = (fresnel_dielectric_cos(dot(L, H), ior) - F0) * F0_norm;
 
   /* Blend between white and a specular color with respect to the fresnel */
-  return cspec0 * (1.0f - FH) + make_float3(1.0f, 1.0f, 1.0f) * FH;
+  return cspec0 * (1.0f - FH) + make_spectral_color(0.0f) * FH;
 }
 
 CCL_NAMESPACE_END

--- a/intern/cycles/kernel/closure/emissive.h
+++ b/intern/cycles/kernel/closure/emissive.h
@@ -34,7 +34,7 @@ CCL_NAMESPACE_BEGIN
 
 /* BACKGROUND CLOSURE */
 
-ccl_device void background_setup(ShaderData *sd, const float3 weight)
+ccl_device void background_setup(ShaderData *sd, const SpectralColor weight)
 {
   if (sd->flag & SD_EMISSION) {
     sd->closure_emission_background += weight;
@@ -47,7 +47,7 @@ ccl_device void background_setup(ShaderData *sd, const float3 weight)
 
 /* EMISSION CLOSURE */
 
-ccl_device void emission_setup(ShaderData *sd, const float3 weight)
+ccl_device void emission_setup(ShaderData *sd, const SpectralColor weight)
 {
   if (sd->flag & SD_EMISSION) {
     sd->closure_emission_background += weight;
@@ -73,11 +73,11 @@ ccl_device void emissive_sample(
   /* todo: not implemented and used yet */
 }
 
-ccl_device float3 emissive_simple_eval(const float3 Ng, const float3 I)
+ccl_device SpectralColor emissive_simple_eval(const float3 Ng, const float3 I)
 {
   float res = emissive_pdf(Ng, I);
 
-  return make_float3(res, res, res);
+  return make_spectral_color(res);
 }
 
 CCL_NAMESPACE_END

--- a/intern/cycles/kernel/kernel_accumulate.h
+++ b/intern/cycles/kernel/kernel_accumulate.h
@@ -21,7 +21,7 @@ CCL_NAMESPACE_BEGIN
  * BSDF evaluation result, split per BSDF type. This is used to accumulate
  * render passes separately. */
 
-ccl_device float3 shader_bsdf_transparency(KernelGlobals *kg, const ShaderData *sd);
+ccl_device SpectralColor shader_bsdf_transparency(KernelGlobals *kg, const ShaderData *sd);
 
 ccl_device_inline void bsdf_eval_init(BsdfEval *eval,
                                       ClosureType type,
@@ -32,11 +32,11 @@ ccl_device_inline void bsdf_eval_init(BsdfEval *eval,
   eval->use_light_pass = use_light_pass;
 
   if (eval->use_light_pass) {
-    eval->diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    eval->glossy = make_float3(0.0f, 0.0f, 0.0f);
-    eval->transmission = make_float3(0.0f, 0.0f, 0.0f);
-    eval->transparent = make_float3(0.0f, 0.0f, 0.0f);
-    eval->volume = make_float3(0.0f, 0.0f, 0.0f);
+    eval->diffuse = make_spectral_color(0.0f);
+    eval->glossy = make_spectral_color(0.0f);
+    eval->transmission = make_spectral_color(0.0f);
+    eval->transparent = make_spectral_color(0.0f);
+    eval->volume = make_spectral_color(0.0f);
 
     if (type == CLOSURE_BSDF_TRANSPARENT_ID)
       eval->transparent = value;
@@ -55,7 +55,7 @@ ccl_device_inline void bsdf_eval_init(BsdfEval *eval,
     eval->diffuse = value;
   }
 #ifdef __SHADOW_TRICKS__
-  eval->sum_no_mis = make_float3(0.0f, 0.0f, 0.0f);
+  eval->sum_no_mis = make_spectral_color(0.0f);
 #endif
 }
 
@@ -174,47 +174,47 @@ ccl_device_inline void path_radiance_init(KernelGlobals *kg, PathRadiance *L)
   L->use_light_pass = kernel_data.film.use_light_pass;
 
   if (kernel_data.film.use_light_pass) {
-    L->indirect = make_float3(0.0f, 0.0f, 0.0f);
-    L->direct_emission = make_float3(0.0f, 0.0f, 0.0f);
+    L->indirect = make_spectral_color(0.0f);
+    L->direct_emission = make_spectral_color(0.0f);
 
-    L->color_diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    L->color_glossy = make_float3(0.0f, 0.0f, 0.0f);
-    L->color_transmission = make_float3(0.0f, 0.0f, 0.0f);
+    L->color_diffuse = make_spectral_color(0.0f);
+    L->color_glossy = make_spectral_color(0.0f);
+    L->color_transmission = make_spectral_color(0.0f);
 
-    L->direct_diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    L->direct_glossy = make_float3(0.0f, 0.0f, 0.0f);
-    L->direct_transmission = make_float3(0.0f, 0.0f, 0.0f);
-    L->direct_volume = make_float3(0.0f, 0.0f, 0.0f);
+    L->direct_diffuse = make_spectral_color(0.0f);
+    L->direct_glossy = make_spectral_color(0.0f);
+    L->direct_transmission = make_spectral_color(0.0f);
+    L->direct_volume = make_spectral_color(0.0f);
 
-    L->indirect_diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    L->indirect_glossy = make_float3(0.0f, 0.0f, 0.0f);
-    L->indirect_transmission = make_float3(0.0f, 0.0f, 0.0f);
-    L->indirect_volume = make_float3(0.0f, 0.0f, 0.0f);
+    L->indirect_diffuse = make_spectral_color(0.0f);
+    L->indirect_glossy = make_spectral_color(0.0f);
+    L->indirect_transmission = make_spectral_color(0.0f);
+    L->indirect_volume = make_spectral_color(0.0f);
 
     L->transparent = 0.0f;
-    L->emission = make_float3(0.0f, 0.0f, 0.0f);
-    L->background = make_float3(0.0f, 0.0f, 0.0f);
-    L->ao = make_float3(0.0f, 0.0f, 0.0f);
+    L->emission = make_spectral_color(0.0f);
+    L->background = make_spectral_color(0.0f);
+    L->ao = make_spectral_color(0.0f);
     L->shadow = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
     L->mist = 0.0f;
 
-    L->state.diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.glossy = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.transmission = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.volume = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.direct = make_float3(0.0f, 0.0f, 0.0f);
+    L->state.diffuse = make_spectral_color(0.0f);
+    L->state.glossy = make_spectral_color(0.0f);
+    L->state.transmission = make_spectral_color(0.0f);
+    L->state.volume = make_spectral_color(0.0f);
+    L->state.direct = make_spectral_color(0.0f);
   }
   else
 #endif
   {
     L->transparent = 0.0f;
-    L->emission = make_float3(0.0f, 0.0f, 0.0f);
+    L->emission = make_spectral_color(0.0f);
   }
 
 #ifdef __SHADOW_TRICKS__
-  L->path_total = make_float3(0.0f, 0.0f, 0.0f);
-  L->path_total_shaded = make_float3(0.0f, 0.0f, 0.0f);
-  L->shadow_background_color = make_float3(0.0f, 0.0f, 0.0f);
+  L->path_total = make_spectral_color(0.0f);
+  L->path_total_shaded = make_spectral_color(0.0f);
+  L->shadow_background_color = make_spectral_color(0.0f);
   L->shadow_throughput = 0.0f;
   L->shadow_transparency = 1.0f;
   L->has_shadow_catcher = 0;
@@ -222,7 +222,7 @@ ccl_device_inline void path_radiance_init(KernelGlobals *kg, PathRadiance *L)
 
 #ifdef __DENOISING_FEATURES__
   L->denoising_normal = make_float3(0.0f, 0.0f, 0.0f);
-  L->denoising_albedo = make_float3(0.0f, 0.0f, 0.0f);
+  L->denoising_albedo = make_spectral_color(0.0f);
   L->denoising_depth = 0.0f;
 #endif
 
@@ -236,7 +236,7 @@ ccl_device_inline void path_radiance_init(KernelGlobals *kg, PathRadiance *L)
 
 ccl_device_inline void path_radiance_bsdf_bounce(KernelGlobals *kg,
                                                  PathRadianceState *L_state,
-                                                 ccl_addr_space float3 *throughput,
+                                                 ccl_addr_space SpectralColor *throughput,
                                                  BsdfEval *bsdf_eval,
                                                  float bsdf_pdf,
                                                  int bounce,
@@ -248,7 +248,7 @@ ccl_device_inline void path_radiance_bsdf_bounce(KernelGlobals *kg,
   if (kernel_data.film.use_light_pass) {
     if (bounce == 0 && !(bsdf_label & LABEL_TRANSPARENT)) {
       /* first on directly visible surface */
-      float3 value = *throughput * inverse_pdf;
+      SpectralColor value = *throughput * inverse_pdf;
 
       L_state->diffuse = bsdf_eval->diffuse * value;
       L_state->glossy = bsdf_eval->glossy * value;
@@ -273,29 +273,29 @@ ccl_device_inline void path_radiance_bsdf_bounce(KernelGlobals *kg,
 }
 
 #ifdef __CLAMP_SAMPLE__
-ccl_device_forceinline void path_radiance_clamp(KernelGlobals *kg, float3 *L, int bounce)
+ccl_device_forceinline void path_radiance_clamp(KernelGlobals *kg, SpectralColor &L, int bounce)
 {
   float limit = (bounce > 0) ? kernel_data.integrator.sample_clamp_indirect :
                                kernel_data.integrator.sample_clamp_direct;
-  float sum = reduce_add(fabs(*L));
+  float sum = reduce_add_spectral(fabs(L));
   if (sum > limit) {
-    *L *= limit / sum;
+    L *= limit / sum;
   }
 }
 
 ccl_device_forceinline void path_radiance_clamp_throughput(KernelGlobals *kg,
-                                                           float3 *L,
-                                                           float3 *throughput,
+                                                           SpectralColor &L,
+                                                           SpectralColor &throughput,
                                                            int bounce)
 {
   float limit = (bounce > 0) ? kernel_data.integrator.sample_clamp_indirect :
                                kernel_data.integrator.sample_clamp_direct;
 
-  float sum = reduce_add(fabs(*L));
+  float sum = reduce_add_spectral(fabs(L));
   if (sum > limit) {
     float clamp_factor = limit / sum;
-    *L *= clamp_factor;
-    *throughput *= clamp_factor;
+    L *= clamp_factor;
+    throughput *= clamp_factor;
   }
 }
 
@@ -304,8 +304,8 @@ ccl_device_forceinline void path_radiance_clamp_throughput(KernelGlobals *kg,
 ccl_device_inline void path_radiance_accum_emission(KernelGlobals *kg,
                                                     PathRadiance *L,
                                                     ccl_addr_space PathState *state,
-                                                    RGBColor throughput,
-                                                    RGBColor value)
+                                                    SpectralColor throughput,
+                                                    SpectralColor value)
 {
 #ifdef __SHADOW_TRICKS__
   if (state->flag & PATH_RAY_SHADOW_CATCHER) {
@@ -313,9 +313,9 @@ ccl_device_inline void path_radiance_accum_emission(KernelGlobals *kg,
   }
 #endif
 
-  RGBColor contribution = throughput * value;
+  SpectralColor contribution = throughput * value;
 #ifdef __CLAMP_SAMPLE__
-  path_radiance_clamp(kg, &contribution, state->bounce - 1);
+  path_radiance_clamp(kg, contribution, state->bounce - 1);
 #endif
 
 #ifdef __PASSES__
@@ -337,10 +337,10 @@ ccl_device_inline void path_radiance_accum_emission(KernelGlobals *kg,
 ccl_device_inline void path_radiance_accum_ao(KernelGlobals *kg,
                                               PathRadiance *L,
                                               ccl_addr_space PathState *state,
-                                              float3 throughput,
-                                              float3 alpha,
-                                              float3 bsdf,
-                                              float3 ao)
+                                              SpectralColor throughput,
+                                              SpectralColor alpha,
+                                              SpectralColor bsdf,
+                                              SpectralColor ao)
 {
 #ifdef __PASSES__
   /* Store AO pass. */
@@ -352,7 +352,7 @@ ccl_device_inline void path_radiance_accum_ao(KernelGlobals *kg,
 #ifdef __SHADOW_TRICKS__
   /* For shadow catcher, accumulate ratio. */
   if (state->flag & PATH_RAY_STORE_SHADOW_INFO) {
-    float3 light = throughput * bsdf;
+    SpectralColor light = throughput * bsdf;
     L->path_total += light;
     L->path_total_shaded += ao * light;
 
@@ -362,7 +362,7 @@ ccl_device_inline void path_radiance_accum_ao(KernelGlobals *kg,
   }
 #endif
 
-  float3 contribution = throughput * bsdf * ao;
+  SpectralColor contribution = throughput * bsdf * ao;
 
 #ifdef __PASSES__
   if (L->use_light_pass) {
@@ -384,8 +384,8 @@ ccl_device_inline void path_radiance_accum_ao(KernelGlobals *kg,
 
 ccl_device_inline void path_radiance_accum_total_ao(PathRadiance *L,
                                                     ccl_addr_space PathState *state,
-                                                    float3 throughput,
-                                                    float3 bsdf)
+                                                    SpectralColor throughput,
+                                                    SpectralColor bsdf)
 {
 #ifdef __SHADOW_TRICKS__
   if (state->flag & PATH_RAY_STORE_SHADOW_INFO) {
@@ -428,7 +428,7 @@ ccl_device_inline void path_radiance_accum_light(KernelGlobals *kg,
      * The resulting scale is then be applied to all individual components. */
     SpectralColor full_contribution = shaded_throughput * bsdf_eval_sum(bsdf_eval);
 #  ifdef __CLAMP_SAMPLE__
-    path_radiance_clamp_throughput(kg, &full_contribution, &shaded_throughput, state->bounce);
+    path_radiance_clamp_throughput(kg, full_contribution, shaded_throughput, state->bounce);
 #  endif
 
     if (state->bounce == 0) {
@@ -452,15 +452,15 @@ ccl_device_inline void path_radiance_accum_light(KernelGlobals *kg,
   else
 #endif
   {
-    float3 contribution = shaded_throughput * bsdf_eval->diffuse;
-    path_radiance_clamp(kg, &contribution, state->bounce);
+    SpectralColor contribution = shaded_throughput * bsdf_eval->diffuse;
+    path_radiance_clamp(kg, contribution, state->bounce);
     L->emission += contribution;
   }
 }
 
 ccl_device_inline void path_radiance_accum_total_light(PathRadiance *L,
                                                        ccl_addr_space PathState *state,
-                                                       float3 throughput,
+                                                       SpectralColor throughput,
                                                        const BsdfEval *bsdf_eval)
 {
 #ifdef __SHADOW_TRICKS__
@@ -478,8 +478,8 @@ ccl_device_inline void path_radiance_accum_total_light(PathRadiance *L,
 ccl_device_inline void path_radiance_accum_background(KernelGlobals *kg,
                                                       PathRadiance *L,
                                                       ccl_addr_space PathState *state,
-                                                      float3 throughput,
-                                                      float3 value)
+                                                      SpectralColor throughput,
+                                                      SpectralColor value)
 {
 
 #ifdef __SHADOW_TRICKS__
@@ -493,9 +493,9 @@ ccl_device_inline void path_radiance_accum_background(KernelGlobals *kg,
   }
 #endif
 
-  float3 contribution = throughput * value;
+  SpectralColor contribution = throughput * value;
 #ifdef __CLAMP_SAMPLE__
-  path_radiance_clamp(kg, &contribution, state->bounce - 1);
+  path_radiance_clamp(kg, contribution, state->bounce - 1);
 #endif
 
 #ifdef __PASSES__
@@ -521,15 +521,15 @@ ccl_device_inline void path_radiance_accum_background(KernelGlobals *kg,
 
 ccl_device_inline void path_radiance_accum_transparent(PathRadiance *L,
                                                        ccl_addr_space PathState *state,
-                                                       float3 throughput)
+                                                       SpectralColor throughput)
 {
   L->transparent += average(throughput);
 }
 
 #ifdef __SHADOW_TRICKS__
 ccl_device_inline void path_radiance_accum_shadowcatcher(PathRadiance *L,
-                                                         float3 throughput,
-                                                         float3 background)
+                                                         SpectralColor throughput,
+                                                         SpectralColor background)
 {
   L->shadow_throughput += average(throughput);
   L->shadow_background_color += throughput * background;
@@ -563,13 +563,13 @@ ccl_device_inline void path_radiance_reset_indirect(PathRadiance *L)
 {
 #ifdef __PASSES__
   if (L->use_light_pass) {
-    L->state.diffuse = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.glossy = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.transmission = make_float3(0.0f, 0.0f, 0.0f);
-    L->state.volume = make_float3(0.0f, 0.0f, 0.0f);
+    L->state.diffuse = make_spectral_color(0.0f);
+    L->state.glossy = make_spectral_color(0.0f);
+    L->state.transmission = make_spectral_color(0.0f);
+    L->state.volume = make_spectral_color(0.0f);
 
-    L->direct_emission = make_float3(0.0f, 0.0f, 0.0f);
-    L->indirect = make_float3(0.0f, 0.0f, 0.0f);
+    L->direct_emission = make_spectral_color(0.0f);
+    L->indirect = make_spectral_color(0.0f);
   }
 #endif
 }
@@ -589,7 +589,7 @@ ccl_device_inline void path_radiance_copy_indirect(PathRadiance *L, const PathRa
 #ifdef __SHADOW_TRICKS__
 ccl_device_inline void path_radiance_sum_shadowcatcher(KernelGlobals *kg,
                                                        PathRadiance *L,
-                                                       float3 *L_sum,
+                                                       SpectralColor *L_sum,
                                                        float *alpha)
 {
   /* Calculate current shadow of the path. */
@@ -623,7 +623,7 @@ ccl_device_inline SpectralColor path_radiance_clamp_and_sum(KernelGlobals *kg,
                                                             PathRadiance *L,
                                                             float *alpha)
 {
-  float3 L_sum;
+  SpectralColor L_sum;
   /* Light Passes are used */
 #ifdef __PASSES__
   SpectralColor L_direct, L_indirect;
@@ -639,24 +639,29 @@ ccl_device_inline SpectralColor path_radiance_clamp_and_sum(KernelGlobals *kg,
       L_direct += L->background;
 
     L_sum = L_direct + L_indirect;
-    float sum = fabsf((L_sum).x) + fabsf((L_sum).y) + fabsf((L_sum).z);
+
+    float sum = 0;
+    SPECTRAL_COLOR_FOR_EACH(i)
+    {
+      sum += fabsf(L_sum[i]);
+    }
 
     /* Reject invalid value */
     if (!isfinite_safe(sum)) {
       kernel_assert(!"Non-finite sum in path_radiance_clamp_and_sum!");
-      L_sum = make_float3(0.0f, 0.0f, 0.0f);
+      L_sum = make_spectral_color(0.0f);
 
-      L->direct_diffuse = make_float3(0.0f, 0.0f, 0.0f);
-      L->direct_glossy = make_float3(0.0f, 0.0f, 0.0f);
-      L->direct_transmission = make_float3(0.0f, 0.0f, 0.0f);
-      L->direct_volume = make_float3(0.0f, 0.0f, 0.0f);
+      L->direct_diffuse = make_spectral_color(0.0f);
+      L->direct_glossy = make_spectral_color(0.0f);
+      L->direct_transmission = make_spectral_color(0.0f);
+      L->direct_volume = make_spectral_color(0.0f);
 
-      L->indirect_diffuse = make_float3(0.0f, 0.0f, 0.0f);
-      L->indirect_glossy = make_float3(0.0f, 0.0f, 0.0f);
-      L->indirect_transmission = make_float3(0.0f, 0.0f, 0.0f);
-      L->indirect_volume = make_float3(0.0f, 0.0f, 0.0f);
+      L->indirect_diffuse = make_spectral_color(0.0f);
+      L->indirect_glossy = make_spectral_color(0.0f);
+      L->indirect_transmission = make_spectral_color(0.0f);
+      L->indirect_volume = make_spectral_color(0.0f);
 
-      L->emission = make_float3(0.0f, 0.0f, 0.0f);
+      L->emission = make_spectral_color(0.0f);
     }
   }
 
@@ -667,10 +672,15 @@ ccl_device_inline SpectralColor path_radiance_clamp_and_sum(KernelGlobals *kg,
     L_sum = L->emission;
 
     /* Reject invalid value */
-    float sum = fabsf((L_sum).x) + fabsf((L_sum).y) + fabsf((L_sum).z);
+    float sum = 0;
+    SPECTRAL_COLOR_FOR_EACH(i)
+    {
+      sum += fabsf(L_sum[i]);
+    }
+
     if (!isfinite_safe(sum)) {
       kernel_assert(!"Non-finite final sum in path_radiance_clamp_and_sum!");
-      L_sum = make_float3(0.0f, 0.0f, 0.0f);
+      L_sum = make_spectral_color(0.0f);
     }
   }
 
@@ -689,8 +699,8 @@ ccl_device_inline SpectralColor path_radiance_clamp_and_sum(KernelGlobals *kg,
 
 ccl_device_inline void path_radiance_split_denoising(KernelGlobals *kg,
                                                      PathRadiance *L,
-                                                     float3 *noisy,
-                                                     float3 *clean)
+                                                     SpectralColor *noisy,
+                                                     SpectralColor *clean)
 {
 #ifdef __PASSES__
   kernel_assert(L->use_light_pass);
@@ -713,7 +723,7 @@ ccl_device_inline void path_radiance_split_denoising(KernelGlobals *kg,
 #  undef ADD_COMPONENT
 #else
   *noisy = L->emission;
-  *clean = make_float3(0.0f, 0.0f, 0.0f);
+  *clean = make_spectral_color(0.0f);
 #endif
 
 #ifdef __SHADOW_TRICKS__
@@ -722,8 +732,8 @@ ccl_device_inline void path_radiance_split_denoising(KernelGlobals *kg,
   }
 #endif
 
-  *noisy = ensure_finite3(*noisy);
-  *clean = ensure_finite3(*clean);
+  *noisy = ensure_finite(*noisy);
+  *clean = ensure_finite(*clean);
 }
 
 ccl_device_inline void path_radiance_accum_sample(PathRadiance *L, PathRadiance *L_sample)

--- a/intern/cycles/kernel/kernel_path_subsurface.h
+++ b/intern/cycles/kernel/kernel_path_subsurface.h
@@ -29,7 +29,7 @@ ccl_device_inline
                                    PathRadiance *L,
                                    ccl_addr_space PathState *state,
                                    ccl_addr_space Ray *ray,
-                                   ccl_addr_space float3 *throughput,
+                                   ccl_addr_space SpectralColor *throughput,
                                    ccl_addr_space SubsurfaceIndirectRays *ss_indirect)
 {
   PROFILING_INIT(kg, PROFILING_SUBSURFACE);
@@ -73,7 +73,7 @@ ccl_device_inline
 
       ccl_addr_space PathState *hit_state = &ss_indirect->state[ss_indirect->num_rays];
       ccl_addr_space Ray *hit_ray = &ss_indirect->rays[ss_indirect->num_rays];
-      ccl_addr_space float3 *hit_tp = &ss_indirect->throughputs[ss_indirect->num_rays];
+      ccl_addr_space SpectralColor *hit_tp = &ss_indirect->throughputs[ss_indirect->num_rays];
       PathRadianceState *hit_L_state = &ss_indirect->L_state[ss_indirect->num_rays];
 
       *hit_state = *state;
@@ -118,7 +118,7 @@ ccl_device void kernel_path_subsurface_setup_indirect(
     ccl_addr_space PathState *state,
     ccl_addr_space Ray *ray,
     PathRadiance *L,
-    ccl_addr_space float3 *throughput)
+    ccl_addr_space SpectralColor *throughput)
 {
   /* Setup state, ray and throughput for indirect SSS rays. */
   ss_indirect->num_rays--;

--- a/intern/cycles/kernel/kernel_path_volume.h
+++ b/intern/cycles/kernel/kernel_path_volume.h
@@ -131,7 +131,7 @@ ccl_device_noinline_cpu bool kernel_path_volume_bounce(KernelGlobals *kg,
 ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg,
                                                           ShaderData *sd,
                                                           ShaderData *emission_sd,
-                                                          float3 throughput,
+                                                          SpectralColor throughput,
                                                           ccl_addr_space PathState *state,
                                                           PathRadiance *L,
                                                           bool sample_all_lights,
@@ -188,7 +188,7 @@ ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg,
 #      endif
       bool has_emission = false;
 
-      float3 tp = throughput;
+      SpectralColor tp = throughput;
 
       if (kernel_data.integrator.use_direct_light) {
         /* sample random position on random light/triangle */
@@ -240,7 +240,7 @@ ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg,
       }
 
       /* trace shadow ray */
-      float3 shadow;
+      SpectralColor shadow;
 
       const bool blocked = shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow);
 

--- a/intern/cycles/kernel/kernel_shadow.h
+++ b/intern/cycles/kernel/kernel_shadow.h
@@ -56,7 +56,7 @@ ccl_device_forceinline bool shadow_handle_transparent_isect(KernelGlobals *kg,
 #endif
                                                             Intersection *isect,
                                                             Ray *ray,
-                                                            float3 *throughput)
+                                                            SpectralColor *throughput)
 {
 #ifdef __VOLUME__
   /* Attenuation between last surface and next surface. */
@@ -93,7 +93,7 @@ ccl_device bool shadow_blocked_opaque(KernelGlobals *kg,
                                       const uint visibility,
                                       Ray *ray,
                                       Intersection *isect,
-                                      float3 *shadow)
+                                      SpectralColor *shadow)
 {
   const bool blocked = scene_intersect(kg, ray, visibility & PATH_RAY_SHADOW_OPAQUE, isect);
 #ifdef __VOLUME__
@@ -147,7 +147,7 @@ ccl_device bool shadow_blocked_transparent_all_loop(KernelGlobals *kg,
                                                     Ray *ray,
                                                     Intersection *hits,
                                                     uint max_hits,
-                                                    float3 *shadow)
+                                                    SpectralColor *shadow)
 {
   /* Intersect to find an opaque surface, or record all transparent
    * surface hits.
@@ -165,7 +165,7 @@ ccl_device bool shadow_blocked_transparent_all_loop(KernelGlobals *kg,
    * shade them.
    */
   if (!blocked && num_hits > 0) {
-    float3 throughput = make_float3(1.0f, 1.0f, 1.0f);
+    SpectralColor throughput = make_spectral_color(1.0f);
     float3 Pend = ray->P + ray->D * ray->t;
     float last_t = 0.0f;
     int bounce = state->transparent_bounce;
@@ -239,7 +239,7 @@ ccl_device bool shadow_blocked_transparent_all(KernelGlobals *kg,
                                                const uint visibility,
                                                Ray *ray,
                                                uint max_hits,
-                                               float3 *shadow)
+                                               SpectralColor *shadow)
 {
 #    ifdef __SPLIT_KERNEL__
   Intersection hits_[SHADOW_STACK_MAX_HITS];
@@ -305,7 +305,7 @@ ccl_device bool shadow_blocked_transparent_stepped_loop(KernelGlobals *kg,
 #      endif
 #    endif
   if (blocked && is_transparent_isect) {
-    float3 throughput = make_float3(1.0f, 1.0f, 1.0f);
+    SpectralColor throughput = make_spectral_color(1.0f);
     float3 Pend = ray->P + ray->D * ray->t;
     int bounce = state->transparent_bounce;
 #    ifdef __VOLUME__
@@ -388,9 +388,9 @@ ccl_device_inline bool shadow_blocked(KernelGlobals *kg,
                                       ShaderData *shadow_sd,
                                       ccl_addr_space PathState *state,
                                       Ray *ray,
-                                      float3 *shadow)
+                                      SpectralColor *shadow)
 {
-  *shadow = make_float3(1.0f, 1.0f, 1.0f);
+  *shadow = make_spectral_color(1.0f);
 #if !defined(__KERNEL_OPTIX__)
   /* Some common early checks.
    * Avoid conditional trace call in OptiX though, since those hurt performance there.

--- a/intern/cycles/kernel/kernel_types.h
+++ b/intern/cycles/kernel/kernel_types.h
@@ -479,17 +479,16 @@ typedef struct DebugData {
 } DebugData;
 #endif
 
-typedef float3 SpectralColor;
 typedef float3 RGBColor;
 
 typedef ccl_addr_space struct PathRadianceState {
 #ifdef __PASSES__
-  float3 diffuse;
-  float3 glossy;
-  float3 transmission;
-  float3 volume;
+  SpectralColor diffuse;
+  SpectralColor glossy;
+  SpectralColor transmission;
+  SpectralColor volume;
 
-  float3 direct;
+  SpectralColor direct;
 #endif
 } PathRadianceState;
 
@@ -532,16 +531,16 @@ typedef ccl_addr_space struct PathRadiance {
 
 #ifdef __SHADOW_TRICKS__
   /* Total light reachable across the path, ignoring shadow blocked queries. */
-  float3 path_total;
+  SpectralColor path_total;
   /* Total light reachable across the path with shadow blocked queries
    * applied here.
    *
    * Dividing this figure by path_total will give estimate of shadow pass.
    */
-  float3 path_total_shaded;
+  SpectralColor path_total_shaded;
 
   /* Color of the background on which shadow is alpha-overed. */
-  float3 shadow_background_color;
+  SpectralColor shadow_background_color;
 
   /* Path radiance sum and throughput at the moment when ray hits shadow
    * catcher object.
@@ -811,7 +810,7 @@ typedef struct AttributeDescriptor {
  * padded to be 16 bytes, while it's only 12 bytes on the GPU. */
 
 #define SHADER_CLOSURE_BASE \
-  float3 weight; \
+  SpectralColor weight; \
   ClosureType type; \
   float sample_weight; \
   float3 N
@@ -999,12 +998,12 @@ typedef ccl_addr_space struct ccl_align(16) ShaderData
   int num_closure;
   int num_closure_left;
   float randb_closure;
-  float3 svm_closure_weight;
+  SpectralColor svm_closure_weight;
 
   /* Closure weights summed directly, so we can evaluate
    * emission and shadow transparency with MAX_CLOSURE 0. */
-  RGBColor closure_emission_background;
-  RGBColor closure_transparent_extinction;
+  SpectralColor closure_emission_background;
+  SpectralColor closure_transparent_extinction;
 
   /* At the end so we can adjust size in ShaderDataTinyStorage. */
   struct ShaderClosure closure[MAX_CLOSURE];
@@ -1049,7 +1048,7 @@ typedef struct PathState {
 
 #ifdef __DENOISING_FEATURES__
   float denoising_feature_weight;
-  float3 denoising_feature_throughput;
+  SpectralColor denoising_feature_throughput;
 #endif /* __DENOISING_FEATURES__ */
 
   /* multiple importance sampling */
@@ -1067,7 +1066,7 @@ typedef struct PathState {
 #endif
 
   /* spectral rendering */
-  float3 wavelengths;
+  float wavelengths[WAVELENGTHS_PER_RAY];
 } PathState;
 
 #ifdef __VOLUME__
@@ -1082,7 +1081,7 @@ typedef struct VolumeState {
 /* Struct to gather multiple nearby intersections. */
 typedef struct LocalIntersection {
   Ray ray;
-  float3 weight[LOCAL_MAX_HITS];
+  SpectralColor weight[LOCAL_MAX_HITS];
 
   int num_hits;
   struct Intersection hits[LOCAL_MAX_HITS];
@@ -1098,7 +1097,7 @@ typedef struct SubsurfaceIndirectRays {
   int num_rays;
 
   struct Ray rays[BSSRDF_MAX_HITS];
-  float3 throughputs[BSSRDF_MAX_HITS];
+  SpectralColor throughputs[BSSRDF_MAX_HITS];
   struct PathRadianceState L_state[BSSRDF_MAX_HITS];
 } SubsurfaceIndirectRays;
 static_assert(BSSRDF_MAX_HITS <= LOCAL_MAX_HITS, "BSSRDF hits too high.");

--- a/intern/cycles/kernel/osl/background.cpp
+++ b/intern/cycles/kernel/osl/background.cpp
@@ -54,7 +54,7 @@ using namespace OSL;
 ///
 class GenericBackgroundClosure : public CClosurePrimitive {
  public:
-  void setup(ShaderData *sd, int /* path_flag */, float3 weight)
+  void setup(ShaderData *sd, int /* path_flag */, SpectralColor weight)
   {
     background_setup(sd, weight);
   }
@@ -69,7 +69,7 @@ class GenericBackgroundClosure : public CClosurePrimitive {
 ///
 class HoldoutClosure : CClosurePrimitive {
  public:
-  void setup(ShaderData *sd, int /* path_flag */, float3 weight)
+  void setup(ShaderData *sd, int /* path_flag */, SpectralColor weight)
   {
     closure_alloc(sd, sizeof(ShaderClosure), CLOSURE_HOLDOUT_ID, weight);
     sd->flag |= SD_HOLDOUT;

--- a/intern/cycles/kernel/osl/bsdf_diffuse_ramp.cpp
+++ b/intern/cycles/kernel/osl/bsdf_diffuse_ramp.cpp
@@ -53,7 +53,7 @@ class DiffuseRampClosure : public CBSDFClosure {
   DiffuseRampBsdf params;
   Color3 colors[8];
 
-  void setup(ShaderData *sd, int /* path_flag */, float3 weight)
+  void setup(ShaderData *sd, int /* path_flag */, SpectralColor weight)
   {
     DiffuseRampBsdf *bsdf = (DiffuseRampBsdf *)bsdf_alloc_osl(
         sd, sizeof(DiffuseRampBsdf), weight, &params);

--- a/intern/cycles/kernel/osl/bsdf_phong_ramp.cpp
+++ b/intern/cycles/kernel/osl/bsdf_phong_ramp.cpp
@@ -52,7 +52,7 @@ class PhongRampClosure : public CBSDFClosure {
   PhongRampBsdf params;
   Color3 colors[8];
 
-  void setup(ShaderData *sd, int /* path_flag */, float3 weight)
+  void setup(ShaderData *sd, int /* path_flag */, SpectralColor weight)
   {
     PhongRampBsdf *bsdf = (PhongRampBsdf *)bsdf_alloc_osl(
         sd, sizeof(PhongRampBsdf), weight, &params);

--- a/intern/cycles/kernel/osl/emissive.cpp
+++ b/intern/cycles/kernel/osl/emissive.cpp
@@ -56,7 +56,7 @@ using namespace OSL;
 ///
 class GenericEmissiveClosure : public CClosurePrimitive {
  public:
-  void setup(ShaderData *sd, int /* path_flag */, float3 weight)
+  void setup(ShaderData *sd, int /* path_flag */, SpectralColor weight)
   {
     emission_setup(sd, weight);
   }

--- a/intern/cycles/kernel/osl/osl_bssrdf.cpp
+++ b/intern/cycles/kernel/osl/osl_bssrdf.cpp
@@ -69,7 +69,7 @@ class CBSSRDFClosure : public CClosurePrimitive {
     params.roughness = 0.0f;
   }
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     if (method == u_cubic) {
       alloc(sd, path_flag, weight, CLOSURE_BSSRDF_CUBIC_ID);
@@ -91,7 +91,7 @@ class CBSSRDFClosure : public CClosurePrimitive {
     }
   }
 
-  void alloc(ShaderData *sd, int path_flag, float3 weight, ClosureType type)
+  void alloc(ShaderData *sd, int path_flag, SpectralColor weight, ClosureType type)
   {
     Bssrdf *bssrdf = bssrdf_alloc(sd, weight);
 
@@ -100,7 +100,7 @@ class CBSSRDFClosure : public CClosurePrimitive {
        * adds considerably noise due to probabilities of continuing path
        * getting lower and lower */
       if (path_flag & PATH_RAY_DIFFUSE_ANCESTOR) {
-        params.radius = make_float3(0.0f, 0.0f, 0.0f);
+        params.radius = make_spectral_color(0.0f);
       }
 
       /* create one closure per color channel */

--- a/intern/cycles/kernel/osl/osl_closures.cpp
+++ b/intern/cycles/kernel/osl/osl_closures.cpp
@@ -203,7 +203,7 @@ CLOSURE_FLOAT3_PARAM(DiffuseClosure, params.N),
  public:
   PrincipledSheenBsdf params;
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     if (!skip(sd, path_flag, LABEL_DIFFUSE)) {
       PrincipledSheenBsdf *bsdf = (PrincipledSheenBsdf *)bsdf_alloc_osl(
@@ -228,7 +228,7 @@ class PrincipledHairClosure : public CBSDFClosure {
  public:
   PrincipledHairBSDF params;
 
-  PrincipledHairBSDF *alloc(ShaderData *sd, int path_flag, float3 weight)
+  PrincipledHairBSDF *alloc(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     PrincipledHairBSDF *bsdf = (PrincipledHairBSDF *)bsdf_alloc_osl(
         sd, sizeof(PrincipledHairBSDF), weight, &params);
@@ -246,7 +246,7 @@ class PrincipledHairClosure : public CBSDFClosure {
     return bsdf;
   }
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     if (!skip(sd, path_flag, LABEL_GLOSSY)) {
       PrincipledHairBSDF *bsdf = (PrincipledHairBSDF *)alloc(sd, path_flag, weight);
@@ -282,7 +282,7 @@ class PrincipledClearcoatClosure : public CBSDFClosure {
   MicrofacetBsdf params;
   float clearcoat, clearcoat_roughness;
 
-  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, float3 weight)
+  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = (MicrofacetBsdf *)bsdf_alloc_osl(
         sd, sizeof(MicrofacetBsdf), weight, &params);
@@ -300,13 +300,13 @@ class PrincipledClearcoatClosure : public CBSDFClosure {
     bsdf->ior = 1.5f;
     bsdf->alpha_x = clearcoat_roughness;
     bsdf->alpha_y = clearcoat_roughness;
-    bsdf->extra->color = make_float3(0.0f, 0.0f, 0.0f);
-    bsdf->extra->cspec0 = make_float3(0.04f, 0.04f, 0.04f);
+    bsdf->extra->color = make_spectral_color(0.0f);
+    bsdf->extra->cspec0 = make_spectral_color(0.04f);
     bsdf->extra->clearcoat = clearcoat;
     return bsdf;
   }
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -513,10 +513,10 @@ bool CBSDFClosure::skip(const ShaderData *sd, int path_flag, int scattering)
 class MicrofacetFresnelClosure : public CBSDFClosure {
  public:
   MicrofacetBsdf params;
-  float3 color;
-  float3 cspec0;
+  SpectralColor color;
+  SpectralColor cspec0;
 
-  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, float3 weight)
+  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     /* Technically, the MultiGGX Glass closure may also transmit. However,
      * since this is set statically and only used for caustic flags, this
@@ -546,7 +546,7 @@ class MicrofacetFresnelClosure : public CBSDFClosure {
 
 class MicrofacetGGXFresnelClosure : public MicrofacetFresnelClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -575,7 +575,7 @@ CCLOSURE_PREPARE(closure_bsdf_microfacet_ggx_fresnel_prepare, MicrofacetGGXFresn
 
 class MicrofacetGGXAnisoFresnelClosure : public MicrofacetFresnelClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -608,9 +608,9 @@ CCLOSURE_PREPARE(closure_bsdf_microfacet_ggx_aniso_fresnel_prepare,
 class MicrofacetMultiClosure : public CBSDFClosure {
  public:
   MicrofacetBsdf params;
-  float3 color;
+  SpectralColor color;
 
-  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, float3 weight)
+  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     /* Technically, the MultiGGX closure may also transmit. However,
      * since this is set statically and only used for caustic flags, this
@@ -632,7 +632,7 @@ class MicrofacetMultiClosure : public CBSDFClosure {
 
     bsdf->extra = extra;
     bsdf->extra->color = color;
-    bsdf->extra->cspec0 = make_float3(0.0f, 0.0f, 0.0f);
+    bsdf->extra->cspec0 = make_spectral_color(0.0f);
     bsdf->extra->clearcoat = 0.0f;
     return bsdf;
   }
@@ -640,7 +640,7 @@ class MicrofacetMultiClosure : public CBSDFClosure {
 
 class MicrofacetMultiGGXClosure : public MicrofacetMultiClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -668,7 +668,7 @@ CCLOSURE_PREPARE(closure_bsdf_microfacet_multi_ggx_prepare, MicrofacetMultiGGXCl
 
 class MicrofacetMultiGGXAnisoClosure : public MicrofacetMultiClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -700,7 +700,7 @@ class MicrofacetMultiGGXGlassClosure : public MicrofacetMultiClosure {
   {
   }
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -731,10 +731,10 @@ CCLOSURE_PREPARE(closure_bsdf_microfacet_multi_ggx_glass_prepare, MicrofacetMult
 class MicrofacetMultiFresnelClosure : public CBSDFClosure {
  public:
   MicrofacetBsdf params;
-  float3 color;
-  float3 cspec0;
+  SpectralColor color;
+  SpectralColor cspec0;
 
-  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, float3 weight)
+  MicrofacetBsdf *alloc(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     /* Technically, the MultiGGX closure may also transmit. However,
      * since this is set statically and only used for caustic flags, this
@@ -764,7 +764,7 @@ class MicrofacetMultiFresnelClosure : public CBSDFClosure {
 
 class MicrofacetMultiGGXFresnelClosure : public MicrofacetMultiFresnelClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -794,7 +794,7 @@ CCLOSURE_PREPARE(closure_bsdf_microfacet_multi_ggx_fresnel_prepare,
 
 class MicrofacetMultiGGXAnisoFresnelClosure : public MicrofacetMultiFresnelClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -828,7 +828,7 @@ class MicrofacetMultiGGXGlassFresnelClosure : public MicrofacetMultiFresnelClosu
   {
   }
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     MicrofacetBsdf *bsdf = alloc(sd, path_flag, weight);
     if (!bsdf) {
@@ -863,7 +863,7 @@ class TransparentClosure : public CBSDFClosure {
   ShaderClosure params;
   float3 unused;
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     bsdf_transparent_setup(sd, weight, path_flag);
   }
@@ -882,7 +882,7 @@ CCLOSURE_PREPARE(closure_bsdf_transparent_prepare, TransparentClosure)
 
 class VolumeAbsorptionClosure : public CBSDFClosure {
  public:
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     volume_extinction_setup(sd, weight);
   }
@@ -901,7 +901,7 @@ class VolumeHenyeyGreensteinClosure : public CBSDFClosure {
  public:
   HenyeyGreensteinVolume params;
 
-  void setup(ShaderData *sd, int path_flag, float3 weight)
+  void setup(ShaderData *sd, int path_flag, SpectralColor weight)
   {
     volume_extinction_setup(sd, weight);
 

--- a/intern/cycles/kernel/osl/osl_closures.h
+++ b/intern/cycles/kernel/osl/osl_closures.h
@@ -111,7 +111,7 @@ void closure_bsdf_principled_hair_prepare(OSL::RendererServices *, int id, void 
 
 class CClosurePrimitive {
  public:
-  virtual void setup(ShaderData *sd, int path_flag, float3 weight) = 0;
+  virtual void setup(ShaderData *sd, int path_flag, SpectralColor weight) = 0;
 
   OSL::ustring label;
 };
@@ -130,7 +130,7 @@ class CBSDFClosure : public CClosurePrimitive {
     structname params; \
     float3 unused; \
 \
-    void setup(ShaderData *sd, int path_flag, float3 weight) \
+    void setup(ShaderData *sd, int path_flag, SpectralColor weight) \
     { \
       if (!skip(sd, path_flag, TYPE)) { \
         structname *bsdf = (structname *)bsdf_alloc_osl(sd, sizeof(structname), weight, &params); \

--- a/intern/cycles/kernel/osl/osl_shader.cpp
+++ b/intern/cycles/kernel/osl/osl_shader.cpp
@@ -164,7 +164,7 @@ static void flatten_surface_closure_tree(ShaderData *sd,
 #ifdef OSL_SUPPORTS_WEIGHTED_CLOSURE_COMPONENTS
         weight = weight * TO_FLOAT3(comp->w);
 #endif
-        prim->setup(sd, path_flag, weight);
+        // prim->setup(sd, path_flag, weight);
       }
       break;
     }
@@ -269,7 +269,7 @@ static void flatten_background_closure_tree(ShaderData *sd,
 #ifdef OSL_SUPPORTS_WEIGHTED_CLOSURE_COMPONENTS
         weight = weight * TO_FLOAT3(comp->w);
 #endif
-        prim->setup(sd, 0, weight);
+        // prim->setup(sd, 0, weight);
       }
       break;
     }
@@ -325,7 +325,7 @@ static void flatten_volume_closure_tree(ShaderData *sd,
 #ifdef OSL_SUPPORTS_WEIGHTED_CLOSURE_COMPONENTS
         weight = weight * TO_FLOAT3(comp->w);
 #endif
-        prim->setup(sd, 0, weight);
+        // prim->setup(sd, 0, weight);
       }
     }
   }

--- a/intern/cycles/kernel/split/kernel_branched.h
+++ b/intern/cycles/kernel/split/kernel_branched.h
@@ -132,7 +132,7 @@ ccl_device_noinline bool kernel_split_branched_path_surface_indirect_light_iter(
 
   ShaderData *sd = saved_sd;
   PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
-  float3 throughput = branched_state->throughput;
+  SpectralColor throughput = branched_state->throughput;
   ccl_global PathState *ps = &kernel_split_state.path_state[ray_index];
 
   float sum_sample_weight = 0.0f;
@@ -185,7 +185,7 @@ ccl_device_noinline bool kernel_split_branched_path_surface_indirect_light_iter(
 
       ps->rng_hash = cmj_hash(branched_state->path_state.rng_hash, i);
 
-      ccl_global float3 *tp = &kernel_split_state.throughput[ray_index];
+      ccl_global SpectralColor *tp = &kernel_split_state.throughput[ray_index];
       *tp = throughput;
 
       ccl_global Ray *bsdf_ray = &kernel_split_state.ray[ray_index];

--- a/intern/cycles/kernel/split/kernel_buffer_update.h
+++ b/intern/cycles/kernel/split/kernel_buffer_update.h
@@ -80,7 +80,7 @@ ccl_device void kernel_buffer_update(KernelGlobals *kg,
     ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
     PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
     ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
-    ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+    ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
     bool ray_was_updated = false;
 
     if (IS_STATE(ray_state, ray_index, RAY_UPDATE_BUFFER)) {
@@ -134,7 +134,7 @@ ccl_device void kernel_buffer_update(KernelGlobals *kg,
           /* Initialize throughput, path radiance, Ray, PathState;
            * These rays proceed with path-iteration.
            */
-          *throughput = make_float3(1.0f, 1.0f, 1.0f);
+          *throughput = make_spectral_color(1.0f);
           path_radiance_init(kg, L);
           path_state_init(kg,
                           AS_SHADER_DATA(&kernel_split_state.sd_DL_shadow[ray_index]),

--- a/intern/cycles/kernel/split/kernel_do_volume.h
+++ b/intern/cycles/kernel/split/kernel_do_volume.h
@@ -53,7 +53,7 @@ ccl_device_noinline bool kernel_split_branched_path_volume_indirect_light_iter(K
     ccl_global Ray *pray = &kernel_split_state.ray[ray_index];
     *pray = branched_state->ray;
 
-    ccl_global float3 *tp = &kernel_split_state.throughput[ray_index];
+    ccl_global SpectralColor *tp = &kernel_split_state.throughput[ray_index];
     *tp = branched_state->throughput * num_samples_inv;
 
     /* branch RNG state */
@@ -104,7 +104,7 @@ ccl_device_noinline bool kernel_split_branched_path_volume_indirect_light_iter(K
   kernel_split_branched_path_indirect_loop_end(kg, ray_index);
 
   /* todo: avoid this calculation using decoupled ray marching */
-  float3 throughput = kernel_split_state.throughput[ray_index];
+  SpectralColor throughput = kernel_split_state.throughput[ray_index];
   kernel_volume_shadow(
       kg, emission_sd, &kernel_split_state.path_state[ray_index], &volume_ray, &throughput);
   kernel_split_state.throughput[ray_index] = throughput;
@@ -143,7 +143,7 @@ ccl_device void kernel_do_volume(KernelGlobals *kg)
 
   if (IS_STATE(ray_state, ray_index, RAY_ACTIVE) ||
       IS_STATE(ray_state, ray_index, RAY_HIT_BACKGROUND)) {
-    ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+    ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
     ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
     ccl_global Intersection *isect = &kernel_split_state.isect[ray_index];
     ShaderData *sd = kernel_split_sd(sd, ray_index);

--- a/intern/cycles/kernel/split/kernel_holdout_emission_blurring_pathtermination_ao.h
+++ b/intern/cycles/kernel/split/kernel_holdout_emission_blurring_pathtermination_ao.h
@@ -91,7 +91,7 @@ ccl_device void kernel_holdout_emission_blurring_pathtermination_ao(
 #endif
 
     ccl_global PathState *state = 0x0;
-    float3 throughput;
+    SpectralColor throughput;
 
     ccl_global char *ray_state = kernel_split_state.ray_state;
     ShaderData *sd = kernel_split_sd(sd, ray_index);

--- a/intern/cycles/kernel/split/kernel_indirect_background.h
+++ b/intern/cycles/kernel/split/kernel_indirect_background.h
@@ -56,7 +56,7 @@ ccl_device void kernel_indirect_background(KernelGlobals *kg)
     ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
     PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
     ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
-    float3 throughput = kernel_split_state.throughput[ray_index];
+    SpectralColor throughput = kernel_split_state.throughput[ray_index];
     ShaderData *sd = kernel_split_sd(sd, ray_index);
     uint buffer_offset = kernel_split_state.buffer_offset[ray_index];
     ccl_global float *buffer = kernel_split_params.tile.buffer + buffer_offset;

--- a/intern/cycles/kernel/split/kernel_indirect_subsurface.h
+++ b/intern/cycles/kernel/split/kernel_indirect_subsurface.h
@@ -48,7 +48,7 @@ ccl_device void kernel_indirect_subsurface(KernelGlobals *kg)
   ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
   PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
   ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
-  ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+  ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
 
   if (IS_STATE(ray_state, ray_index, RAY_UPDATE_BUFFER)) {
     ccl_addr_space SubsurfaceIndirectRays *ss_indirect = &kernel_split_state.ss_rays[ray_index];

--- a/intern/cycles/kernel/split/kernel_lamp_emission.h
+++ b/intern/cycles/kernel/split/kernel_lamp_emission.h
@@ -55,7 +55,7 @@ ccl_device void kernel_lamp_emission(KernelGlobals *kg)
     PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
     ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
 
-    float3 throughput = kernel_split_state.throughput[ray_index];
+    SpectralColor throughput = kernel_split_state.throughput[ray_index];
     Ray ray = kernel_split_state.ray[ray_index];
     ccl_global Intersection *isect = &kernel_split_state.isect[ray_index];
     ShaderData *sd = kernel_split_sd(sd, ray_index);

--- a/intern/cycles/kernel/split/kernel_next_iteration_setup.h
+++ b/intern/cycles/kernel/split/kernel_next_iteration_setup.h
@@ -55,7 +55,7 @@ ccl_device_inline void kernel_split_branched_indirect_light_init(KernelGlobals *
 
 ccl_device void kernel_split_branched_transparent_bounce(KernelGlobals *kg, int ray_index)
 {
-  ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+  ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
   ShaderData *sd = kernel_split_sd(sd, ray_index);
   ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
   ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
@@ -141,7 +141,7 @@ ccl_device void kernel_next_iteration_setup(KernelGlobals *kg,
 
   bool active = IS_STATE(ray_state, ray_index, RAY_ACTIVE);
   if (active) {
-    ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+    ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
     ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
     ShaderData *sd = kernel_split_sd(sd, ray_index);
     ccl_global PathState *state = &kernel_split_state.path_state[ray_index];

--- a/intern/cycles/kernel/split/kernel_path_init.h
+++ b/intern/cycles/kernel/split/kernel_path_init.h
@@ -58,7 +58,7 @@ ccl_device void kernel_path_init(KernelGlobals *kg)
     /* Initialize throughput, path radiance, Ray, PathState;
      * These rays proceed with path-iteration.
      */
-    kernel_split_state.throughput[ray_index] = make_float3(1.0f, 1.0f, 1.0f);
+    kernel_split_state.throughput[ray_index] = make_spectral_color(1.0f);
     path_radiance_init(kg, &kernel_split_state.path_radiance[ray_index]);
     path_state_init(kg,
                     AS_SHADER_DATA(&kernel_split_state.sd_DL_shadow[ray_index]),

--- a/intern/cycles/kernel/split/kernel_shadow_blocked_ao.h
+++ b/intern/cycles/kernel/split/kernel_shadow_blocked_ao.h
@@ -41,7 +41,7 @@ ccl_device void kernel_shadow_blocked_ao(KernelGlobals *kg)
   ShaderData *emission_sd = AS_SHADER_DATA(&kernel_split_state.sd_DL_shadow[ray_index]);
   PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
   ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
-  float3 throughput = kernel_split_state.throughput[ray_index];
+  SpectralColor throughput = kernel_split_state.throughput[ray_index];
 
 #ifdef __BRANCHED_PATH__
   if (!kernel_data.integrator.branched ||

--- a/intern/cycles/kernel/split/kernel_shadow_blocked_dl.h
+++ b/intern/cycles/kernel/split/kernel_shadow_blocked_dl.h
@@ -48,7 +48,7 @@ ccl_device void kernel_shadow_blocked_dl(KernelGlobals *kg)
   Ray ray = kernel_split_state.light_ray[ray_index];
   PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
   ShaderData *sd = kernel_split_sd(sd, ray_index);
-  float3 throughput = kernel_split_state.throughput[ray_index];
+  SpectralColor throughput = kernel_split_state.throughput[ray_index];
 
   BsdfEval L_light = kernel_split_state.bsdf_eval[ray_index];
   ShaderData *emission_sd = AS_SHADER_DATA(&kernel_split_state.sd_DL_shadow[ray_index]);
@@ -83,7 +83,7 @@ ccl_device void kernel_shadow_blocked_dl(KernelGlobals *kg)
 #endif /* defined(__BRANCHED_PATH__) || defined(__SHADOW_TRICKS__)*/
   {
     /* trace shadow ray */
-    float3 shadow;
+    SpectralColor shadow;
 
     if (!shadow_blocked(kg, sd, emission_sd, state, &ray, &shadow)) {
       /* accumulate */

--- a/intern/cycles/kernel/split/kernel_split_data_types.h
+++ b/intern/cycles/kernel/split/kernel_split_data_types.h
@@ -49,7 +49,7 @@ typedef struct SplitParams {
 typedef ccl_global struct SplitBranchedState {
   /* various state that must be kept and restored after an indirect loop */
   PathState path_state;
-  float3 throughput;
+  SpectralColor throughput;
   Ray ray;
 
   Intersection isect;
@@ -96,7 +96,7 @@ typedef ccl_global struct SplitBranchedState {
 #endif /* __VOLUME__ */
 
 #define SPLIT_DATA_ENTRIES \
-  SPLIT_DATA_ENTRY(ccl_global float3, throughput, 1) \
+  SPLIT_DATA_ENTRY(ccl_global SpectralColor, throughput, 1) \
   SPLIT_DATA_ENTRY(PathRadiance, path_radiance, 1) \
   SPLIT_DATA_ENTRY(ccl_global Ray, ray, 1) \
   SPLIT_DATA_ENTRY(ccl_global PathState, path_state, 1) \

--- a/intern/cycles/kernel/split/kernel_subsurface_scatter.h
+++ b/intern/cycles/kernel/split/kernel_subsurface_scatter.h
@@ -205,7 +205,7 @@ ccl_device void kernel_subsurface_scatter(KernelGlobals *kg)
     ccl_global PathState *state = &kernel_split_state.path_state[ray_index];
     PathRadiance *L = &kernel_split_state.path_radiance[ray_index];
     ccl_global Ray *ray = &kernel_split_state.ray[ray_index];
-    ccl_global float3 *throughput = &kernel_split_state.throughput[ray_index];
+    ccl_global SpectralColor *throughput = &kernel_split_state.throughput[ray_index];
     ccl_global SubsurfaceIndirectRays *ss_indirect = &kernel_split_state.ss_rays[ray_index];
     ShaderData *sd = kernel_split_sd(sd, ray_index);
     ShaderData *emission_sd = AS_SHADER_DATA(&kernel_split_state.sd_DL_shadow[ray_index]);

--- a/intern/cycles/kernel/svm/svm.h
+++ b/intern/cycles/kernel/svm/svm.h
@@ -60,6 +60,29 @@ ccl_device_inline void stack_store_float3(float *stack, uint a, float3 f)
   stack[a + 2] = f.z;
 }
 
+ccl_device_inline SpectralColor stack_load_spectral(float *stack, uint a)
+{
+  kernel_assert(a + WAVELENGTHS_PER_RAY - 1 < SVM_STACK_SIZE);
+
+  SpectralColor spectral;
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    spectral[i] = stack[a + i];
+  }
+
+  return spectral;
+}
+
+ccl_device_inline void stack_store_spectral(float *stack, uint a, const SpectralColor &spectral)
+{
+  kernel_assert(a + WAVELENGTHS_PER_RAY - 1 < SVM_STACK_SIZE);
+
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    stack[a + i] = spectral[i];
+  }
+}
+
 ccl_device_inline float stack_load_float(float *stack, uint a)
 {
   kernel_assert(a < SVM_STACK_SIZE);
@@ -256,7 +279,7 @@ ccl_device_noinline void svm_eval_nodes(KernelGlobals *kg,
         svm_node_closure_background(sd, stack, node);
         break;
       case NODE_CLOSURE_SET_WEIGHT:
-        svm_node_closure_set_weight(sd, node.y, node.z, node.w);
+        svm_node_closure_set_weight(sd, stack, node.y);
         break;
       case NODE_CLOSURE_WEIGHT:
         svm_node_closure_weight(sd, stack, node.y);

--- a/intern/cycles/kernel/svm/svm_blackbody.h
+++ b/intern/cycles/kernel/svm/svm_blackbody.h
@@ -57,12 +57,13 @@ ccl_device void svm_node_blackbody(
   float peak_wavelength = clamp(b / temperature, 360.0e-9f, 730.0e-9f);
   float peak_intensity = blackbody_intensity(temperature, peak_wavelength);
 
-  float3 spectral = make_float3(
-      blackbody_intensity(temperature, state->wavelengths.x * 1e-9f) / peak_intensity,
-      blackbody_intensity(temperature, state->wavelengths.y * 1e-9f) / peak_intensity,
-      blackbody_intensity(temperature, state->wavelengths.z * 1e-9f) / peak_intensity);
+  SpectralColor spectral;
+  SPECTRAL_COLOR_FOR_EACH_WAVELENGTH(state->wavelengths, i, wavelength)
+  {
+    spectral[i] = blackbody_intensity(temperature, wavelength * 1e-9f) / peak_intensity;
+  }
 
-  stack_store_float3(stack, col_offset, spectral);
+  stack_store_spectral(stack, col_offset, spectral);
 }
 
 CCL_NAMESPACE_END

--- a/intern/cycles/render/graph.cpp
+++ b/intern/cycles/render/graph.cpp
@@ -833,24 +833,6 @@ void ShaderGraph::expand()
   foreach (ShaderNode *node, nodes) {
     node->expand(this);
   }
-
-  /* Connect RGB node to unconnected spectral sockets to force color to spectral conversion. */
-  foreach (ShaderNode *node, nodes) {
-    foreach (ShaderInput *input, node->inputs) {
-      if (input->type() == SocketType::SPECTRAL && !input->link) {
-        float3 color = input->parent->get_float3(input->socket_type);
-        if (color == make_float3(0.0f, 0.0f, 0.0f)) {
-          continue;
-        }
-
-        auto node = new RGBToSpectralNode();
-        node->set(node->input("Color")->socket_type, color);
-
-        add(node);
-        connect(node->output("Spectral"), input);
-      }
-    }
-  }
 }
 
 void ShaderGraph::default_inputs(bool do_osl)

--- a/intern/cycles/render/nodes.cpp
+++ b/intern/cycles/render/nodes.cpp
@@ -2172,7 +2172,7 @@ NODE_DEFINE(AnisotropicBsdfNode)
 {
   NodeType *type = NodeType::add("anisotropic_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2235,7 +2235,7 @@ NODE_DEFINE(GlossyBsdfNode)
 {
   NodeType *type = NodeType::add("glossy_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2327,7 +2327,7 @@ NODE_DEFINE(GlassBsdfNode)
 {
   NodeType *type = NodeType::add("glass_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2420,7 +2420,7 @@ NODE_DEFINE(RefractionBsdfNode)
 {
   NodeType *type = NodeType::add("refraction_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2511,7 +2511,7 @@ NODE_DEFINE(ToonBsdfNode)
 {
   NodeType *type = NodeType::add("toon_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2551,7 +2551,7 @@ NODE_DEFINE(VelvetBsdfNode)
 {
   NodeType *type = NodeType::add("velvet_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
   SOCKET_IN_FLOAT(sigma, "Sigma", 1.0f);
@@ -2582,7 +2582,7 @@ NODE_DEFINE(DiffuseBsdfNode)
 {
   NodeType *type = NodeType::add("diffuse_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
   SOCKET_IN_FLOAT(roughness, "Roughness", 0.0f);
@@ -2626,11 +2626,11 @@ NODE_DEFINE(PrincipledBsdfNode)
               subsurface_method_enum,
               CLOSURE_BSSRDF_PRINCIPLED_ID);
 
-  SOCKET_IN_SPECTRAL(base_color, "Base Color", make_float3(0.8f, 0.8f, 0.8f));
-  SOCKET_IN_SPECTRAL(subsurface_color, "Subsurface Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(base_color, "Base Color", make_spectral_color(0.8f));
+  SOCKET_IN_SPECTRAL(subsurface_color, "Subsurface Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(metallic, "Metallic", 0.0f);
   SOCKET_IN_FLOAT(subsurface, "Subsurface", 0.0f);
-  SOCKET_IN_VECTOR(subsurface_radius, "Subsurface Radius", make_float3(0.1f, 0.1f, 0.1f));
+  SOCKET_IN_SPECTRAL(subsurface_radius, "Subsurface Radius", make_spectral_color(0.1f));
   SOCKET_IN_FLOAT(specular, "Specular", 0.0f);
   SOCKET_IN_FLOAT(roughness, "Roughness", 0.5f);
   SOCKET_IN_FLOAT(specular_tint, "Specular Tint", 0.0f);
@@ -2643,7 +2643,7 @@ NODE_DEFINE(PrincipledBsdfNode)
   SOCKET_IN_FLOAT(transmission, "Transmission", 0.0f);
   SOCKET_IN_FLOAT(transmission_roughness, "Transmission Roughness", 0.0f);
   SOCKET_IN_FLOAT(anisotropic_rotation, "Anisotropic Rotation", 0.0f);
-  SOCKET_IN_SPECTRAL(emission, "Emission", make_float3(0.0f, 0.0f, 0.0f));
+  SOCKET_IN_SPECTRAL(emission, "Emission", make_spectral_color(0.0f));
   SOCKET_IN_FLOAT(alpha, "Alpha", 1.0f);
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_NORMAL(clearcoat_normal,
@@ -2670,7 +2670,7 @@ void PrincipledBsdfNode::expand(ShaderGraph *graph)
   ShaderOutput *principled_out = output("BSDF");
 
   ShaderInput *emission_in = input("Emission");
-  if (emission_in->link || emission != make_float3(0.0f, 0.0f, 0.0f)) {
+  if (emission_in->link) {
     /* Create add closure and emission. */
     AddClosureNode *add = new AddClosureNode();
     EmissionNode *emission_node = new EmissionNode();
@@ -2793,24 +2793,29 @@ void PrincipledBsdfNode::compile(SVMCompiler &compiler,
                     subsurface_method,
                     SVM_STACK_INVALID);
 
-  float3 bc_default = get_float3(base_color_in->socket_type);
+  //   float3 bc_default = get_float3(base_color_in->socket_type);
 
-  compiler.add_node(
-      ((base_color_in->link) ? compiler.stack_assign(base_color_in) : SVM_STACK_INVALID),
-      __float_as_int(bc_default.x),
-      __float_as_int(bc_default.y),
-      __float_as_int(bc_default.z));
+  compiler.add_node(compiler.stack_assign(base_color_in));
+
+  //   compiler.add_node(
+  //       ((base_color_in->link) ? compiler.stack_assign(base_color_in) : SVM_STACK_INVALID),
+  //       __float_as_int(bc_default.x),
+  //       __float_as_int(bc_default.y),
+  //       __float_as_int(bc_default.z));
 
   compiler.add_node(
       clearcoat_normal_offset, subsurface_radius_offset, SVM_STACK_INVALID, SVM_STACK_INVALID);
 
-  float3 ss_default = get_float3(subsurface_color_in->socket_type);
+  //   float3 ss_default = get_float3(subsurface_color_in->socket_type);
 
-  compiler.add_node(((subsurface_color_in->link) ? compiler.stack_assign(subsurface_color_in) :
-                                                   SVM_STACK_INVALID),
-                    __float_as_int(ss_default.x),
-                    __float_as_int(ss_default.y),
-                    __float_as_int(ss_default.z));
+  compiler.add_node(compiler.stack_assign(subsurface_color_in));
+
+  //   compiler.add_node(((subsurface_color_in->link) ? compiler.stack_assign(subsurface_color_in)
+  //   :
+  //                                                    SVM_STACK_INVALID),
+  //                     __float_as_int(ss_default.x),
+  //                     __float_as_int(ss_default.y),
+  //                     __float_as_int(ss_default.z));
 }
 
 bool PrincipledBsdfNode::has_integrator_dependency()
@@ -2857,7 +2862,7 @@ NODE_DEFINE(TranslucentBsdfNode)
 {
   NodeType *type = NodeType::add("translucent_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2887,7 +2892,7 @@ NODE_DEFINE(TransparentBsdfNode)
 {
   NodeType *type = NodeType::add("transparent_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(1.0f, 1.0f, 1.0f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
   SOCKET_OUT_CLOSURE(BSDF, "BSDF");
@@ -2916,7 +2921,7 @@ NODE_DEFINE(SubsurfaceScatteringNode)
 {
   NodeType *type = NodeType::add("subsurface_scattering", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -2969,7 +2974,7 @@ NODE_DEFINE(EmissionNode)
 {
   NodeType *type = NodeType::add("emission", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(strength, "Strength", 10.0f);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -3019,7 +3024,7 @@ NODE_DEFINE(BackgroundNode)
 {
   NodeType *type = NodeType::add("background_shader", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(strength, "Strength", 1.0f);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -3194,7 +3199,7 @@ NODE_DEFINE(AbsorptionVolumeNode)
 {
   NodeType *type = NodeType::add("absorption_volume", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(density, "Density", 1.0f);
   SOCKET_IN_FLOAT(volume_mix_weight, "VolumeMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -3224,7 +3229,7 @@ NODE_DEFINE(ScatterVolumeNode)
 {
   NodeType *type = NodeType::add("scatter_volume", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_FLOAT(density, "Density", 1.0f);
   SOCKET_IN_FLOAT(anisotropy, "Anisotropy", 0.0f);
   SOCKET_IN_FLOAT(volume_mix_weight, "VolumeMixWeight", 0.0f, SocketType::SVM_INTERNAL);
@@ -3259,14 +3264,14 @@ NODE_DEFINE(PrincipledVolumeNode)
   SOCKET_IN_STRING(color_attribute, "Color Attribute", ustring());
   SOCKET_IN_STRING(temperature_attribute, "Temperature Attribute", ustring());
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.5f, 0.5f, 0.5f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.5f));
   SOCKET_IN_FLOAT(density, "Density", 1.0f);
   SOCKET_IN_FLOAT(anisotropy, "Anisotropy", 0.0f);
-  SOCKET_IN_SPECTRAL(absorption_color, "Absorption Color", make_float3(0.0f, 0.0f, 0.0f));
+  SOCKET_IN_SPECTRAL(absorption_color, "Absorption Color", make_spectral_color(0.0f));
   SOCKET_IN_FLOAT(emission_strength, "Emission Strength", 0.0f);
-  SOCKET_IN_SPECTRAL(emission_color, "Emission Color", make_float3(1.0f, 1.0f, 1.0f));
+  SOCKET_IN_SPECTRAL(emission_color, "Emission Color", make_spectral_color(1.0f));
   SOCKET_IN_FLOAT(blackbody_intensity, "Blackbody Intensity", 0.0f);
-  SOCKET_IN_SPECTRAL(blackbody_tint, "Blackbody Tint", make_float3(1.0f, 1.0f, 1.0f));
+  SOCKET_IN_SPECTRAL(blackbody_tint, "Blackbody Tint", make_spectral_color(1.0f));
   SOCKET_IN_FLOAT(temperature, "Temperature", 1000.0f);
   SOCKET_IN_FLOAT(volume_mix_weight, "VolumeMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 
@@ -3373,10 +3378,10 @@ NODE_DEFINE(PrincipledHairBsdfNode)
       parametrization, "Parametrization", parametrization_enum, NODE_PRINCIPLED_HAIR_REFLECTANCE);
 
   /* Initialize sockets to their default values. */
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.017513f, 0.005763f, 0.002059f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.5f));
   SOCKET_IN_FLOAT(melanin, "Melanin", 0.8f);
   SOCKET_IN_FLOAT(melanin_redness, "Melanin Redness", 1.0f);
-  SOCKET_IN_SPECTRAL(tint, "Tint", make_float3(1.f, 1.f, 1.f));
+  SOCKET_IN_SPECTRAL(tint, "Tint", make_spectral_color(1.0f));
   SOCKET_IN_VECTOR(absorption_coefficient,
                    "Absorption Coefficient",
                    make_float3(0.245531f, 0.52f, 1.365f),
@@ -3493,7 +3498,7 @@ NODE_DEFINE(HairBsdfNode)
 {
   NodeType *type = NodeType::add("hair_bsdf", create, NodeType::SHADER);
 
-  SOCKET_IN_SPECTRAL(color, "Color", make_float3(0.8f, 0.8f, 0.8f));
+  SOCKET_IN_SPECTRAL(color, "Color", make_spectral_color(0.8f));
   SOCKET_IN_NORMAL(normal, "Normal", make_float3(0.0f, 0.0f, 0.0f), SocketType::LINK_NORMAL);
   SOCKET_IN_FLOAT(surface_mix_weight, "SurfaceMixWeight", 0.0f, SocketType::SVM_INTERNAL);
 

--- a/intern/cycles/render/nodes.h
+++ b/intern/cycles/render/nodes.h
@@ -558,8 +558,8 @@ class PrincipledBsdfNode : public BsdfBaseNode {
                ShaderInput *anisotropic_rotation,
                ShaderInput *transmission_roughness);
 
-  float3 base_color;
-  float3 subsurface_color, subsurface_radius;
+  SpectralColor base_color;
+  SpectralColor subsurface_color, subsurface_radius;
   float metallic, subsurface, specular, roughness, specular_tint, anisotropic, sheen, sheen_tint,
       clearcoat, clearcoat_roughness, ior, transmission, anisotropic_rotation,
       transmission_roughness;
@@ -567,7 +567,7 @@ class PrincipledBsdfNode : public BsdfBaseNode {
   float surface_mix_weight;
   ClosureType distribution, distribution_orig;
   ClosureType subsurface_method;
-  float3 emission;
+  SpectralColor emission;
   float alpha;
 
   bool has_integrator_dependency();

--- a/intern/cycles/render/svm.cpp
+++ b/intern/cycles/render/svm.cpp
@@ -192,11 +192,13 @@ int SVMCompiler::stack_size(SocketType::Type type)
     case SocketType::VECTOR:
     case SocketType::NORMAL:
     case SocketType::POINT:
-    case SocketType::SPECTRAL:
       size = 3;
       break;
     case SocketType::CLOSURE:
       size = 0;
+      break;
+    case SocketType::SPECTRAL:
+      size = WAVELENGTHS_PER_RAY;
       break;
     default:
       assert(0);

--- a/intern/cycles/util/CMakeLists.txt
+++ b/intern/cycles/util/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SRC_HEADERS
   util_math_int3.h
   util_math_int4.h
   util_math_matrix.h
+  util_math_spectral_color.h
   util_md5.h
   util_murmurhash.h
   util_opengl.h
@@ -131,6 +132,8 @@ set(SRC_HEADERS
   util_types_int3_impl.h
   util_types_int4.h
   util_types_int4_impl.h
+  util_types_spectral_color.h
+  util_types_spectral_color_impl.h
   util_types_uchar2.h
   util_types_uchar2_impl.h
   util_types_uchar3.h

--- a/intern/cycles/util/util_math.h
+++ b/intern/cycles/util/util_math.h
@@ -523,12 +523,31 @@ ccl_device_inline SpectralColor safe_divide_color(SpectralColor a, SpectralColor
   return color;
 }
 
+ccl_device_inline float3 safe_divide_color(float3 a, float3 b)
+{
+  float3 color;
+
+  color[0] = (b[0] != 0.0f) ? a[0] / b[0] : 0.0f;
+  color[1] = (b[1] != 0.0f) ? a[1] / b[1] : 0.0f;
+  color[2] = (b[2] != 0.0f) ? a[2] / b[2] : 0.0f;
+
+  return color;
+}
+
 ccl_device_inline SpectralColor safe_divide_even_color(SpectralColor a, SpectralColor b)
 {
   SpectralColor s = safe_divide_color(a, b);
   float f = reduce_add_spectral(s);
 
   return make_spectral_color(f / WAVELENGTHS_PER_RAY);
+}
+
+ccl_device_inline float3 safe_divide_even_color(float3 a, float3 b)
+{
+  float3 s = safe_divide_color(a, b);
+  float f = s[0] + s[1] + s[2];
+
+  return make_float3(f / 3);
 }
 
 ccl_device_inline SpectralColor saturate(SpectralColor a)

--- a/intern/cycles/util/util_math.h
+++ b/intern/cycles/util/util_math.h
@@ -447,6 +447,8 @@ CCL_NAMESPACE_END
 #include "util/util_math_float3.h"
 #include "util/util_math_float4.h"
 
+#include "util/util_math_spectral_color.h"
+
 #include "util/util_rect.h"
 
 CCL_NAMESPACE_BEGIN
@@ -500,62 +502,60 @@ ccl_device_inline void make_orthonormals(const float3 N, float3 *a, float3 *b)
 
 /* Color division */
 
-ccl_device_inline float3 safe_invert_color(float3 a)
+ccl_device_inline SpectralColor safe_invert_color(SpectralColor a)
 {
-  float x, y, z;
-
-  x = (a.x != 0.0f) ? 1.0f / a.x : 0.0f;
-  y = (a.y != 0.0f) ? 1.0f / a.y : 0.0f;
-  z = (a.z != 0.0f) ? 1.0f / a.z : 0.0f;
-
-  return make_float3(x, y, z);
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    a[i] = (a[i] != 0.0f) ? 1.0f / a[i] : 0.0f;
+  }
+  return a;
 }
 
-ccl_device_inline float3 safe_divide_color(float3 a, float3 b)
+ccl_device_inline SpectralColor safe_divide_color(SpectralColor a, SpectralColor b)
 {
-  float x, y, z;
+  SpectralColor color;
 
-  x = (b.x != 0.0f) ? a.x / b.x : 0.0f;
-  y = (b.y != 0.0f) ? a.y / b.y : 0.0f;
-  z = (b.z != 0.0f) ? a.z / b.z : 0.0f;
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    color[i] = (b[i] != 0.0f) ? a[i] / b[i] : 0.0f;
+  }
 
-  return make_float3(x, y, z);
+  return color;
 }
 
-ccl_device_inline float3 safe_divide_even_color(float3 a, float3 b)
+ccl_device_inline SpectralColor safe_divide_even_color(SpectralColor a, SpectralColor b)
 {
-  float x, y, z;
+  SpectralColor s = safe_divide_color(a, b);
+  float f = reduce_add_spectral(s);
 
-  x = (b.x != 0.0f) ? a.x / b.x : 0.0f;
-  y = (b.y != 0.0f) ? a.y / b.y : 0.0f;
-  z = (b.z != 0.0f) ? a.z / b.z : 0.0f;
+  return make_spectral_color(f / WAVELENGTHS_PER_RAY);
+}
 
-  /* try to get gray even if b is zero */
-  if (b.x == 0.0f) {
-    if (b.y == 0.0f) {
-      x = z;
-      y = z;
-    }
-    else if (b.z == 0.0f) {
-      x = y;
-      z = y;
-    }
-    else
-      x = 0.5f * (y + z);
+ccl_device_inline SpectralColor saturate(SpectralColor a)
+{
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    a[i] = clamp(a[i], 0.0f, 1.0f);
   }
-  else if (b.y == 0.0f) {
-    if (b.z == 0.0f) {
-      y = x;
-      z = x;
+  return a;
+}
+
+ccl_device_inline bool isequal(const SpectralColor a, const SpectralColor b)
+{
+  // #ifdef __KERNEL_OPENCL__
+  //   return all(a == b);
+  // #else
+  //   return a == b;
+  // #endif
+
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    if (a[i] != b[i]) {
+      return false;
     }
-    else
-      y = 0.5f * (x + z);
-  }
-  else if (b.z == 0.0f) {
-    z = 0.5f * (x + y);
   }
 
-  return make_float3(x, y, z);
+  return true;
 }
 
 /* Rotation of point around axis and angle */

--- a/intern/cycles/util/util_math_spectral_color.h
+++ b/intern/cycles/util/util_math_spectral_color.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2011-2017 Blender Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __UTIL_MATH_SPECTRAL_COLOR_H__
+#define __UTIL_MATH_SPECTRAL_COLOR_H__
+
+#ifndef __UTIL_MATH_H__
+#  error "Do not include this file directly, include util_types.h instead."
+#endif
+
+CCL_NAMESPACE_BEGIN
+
+ccl_device_inline SpectralColor ensure_finite(SpectralColor v)
+{
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    v[i] = (isfinite_safe(v[i])) ? v[i] : 0.0f;
+  }
+  return v;
+}
+
+ccl_device_inline float reduce_add_spectral(const SpectralColor &a)
+{
+  float f = 0.0f;
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    f += a[i];
+  }
+  return f;
+}
+
+ccl_device_inline float reduce_max_spectral(const SpectralColor &a)
+{
+  float f = -INFINITY;
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    f = max(f, a[i]);
+  }
+  return f;
+}
+
+ccl_device_inline SpectralColor fabs(SpectralColor &a)
+{
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    a[i] += fabsf(a[i]);
+  }
+  return a;
+}
+
+ccl_device_inline SpectralColor exp_s(SpectralColor v)
+{
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    v[i] = expf(v[i]);
+  }
+  return v;
+}
+
+ccl_device_inline SpectralColor log_s(SpectralColor v)
+{
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    v[i] = logf(v[i]);
+  }
+  return v;
+}
+
+CCL_NAMESPACE_END
+
+#endif /* __UTIL_MATH_SPECTRAL_COLOR_H__ */

--- a/intern/cycles/util/util_types.h
+++ b/intern/cycles/util/util_types.h
@@ -130,6 +130,8 @@ CCL_NAMESPACE_END
 
 #include "util/util_types_vector3.h"
 
+#include "util/util_types_spectral_color.h"
+
 /* Vectorized types implementation. */
 #include "util/util_types_uchar2_impl.h"
 #include "util/util_types_uchar3_impl.h"
@@ -149,6 +151,8 @@ CCL_NAMESPACE_END
 #include "util/util_types_float8_impl.h"
 
 #include "util/util_types_vector3_impl.h"
+
+#include "util/util_types_spectral_color_impl.h"
 
 /* SSE types. */
 #ifndef __KERNEL_GPU__

--- a/intern/cycles/util/util_types_spectral_color.h
+++ b/intern/cycles/util/util_types_spectral_color.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2011-2017 Blender Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __UTIL_TYPES_SPECTRAL_COLOR_H__
+#define __UTIL_TYPES_SPECTRAL_COLOR_H__
+
+#ifndef __UTIL_TYPES_H__
+#  error "Do not include this file directly, include util_types.h instead."
+#endif
+
+CCL_NAMESPACE_BEGIN
+
+#define WAVELENGTHS_PER_RAY 4
+typedef float4 SpectralColor;
+
+#define SPECTRAL_COLOR_FOR_EACH(counter) \
+  for (int counter = 0; counter < WAVELENGTHS_PER_RAY; counter++)
+
+#define SPECTRAL_COLOR_FOR_EACH_WAVELENGTH(wavelengths, counter, wavelength) \
+  float wavelength = wavelengths[0]; \
+  for (int counter = 0; counter < WAVELENGTHS_PER_RAY; \
+       counter++, wavelength = wavelengths[counter])
+
+ccl_device_inline SpectralColor make_spectral_color(float value);
+
+CCL_NAMESPACE_END
+
+#endif /* __UTIL_TYPES_FLOAT4_H__ */

--- a/intern/cycles/util/util_types_spectral_color_impl.h
+++ b/intern/cycles/util/util_types_spectral_color_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 Blender Foundation
+ * Copyright 2011-2017 Blender Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,29 @@
  * limitations under the License.
  */
 
+#ifndef __UTIL_TYPES_SPECTRAL_COLOR_IMPL_H__
+#define __UTIL_TYPES_SPECTRAL_COLOR_IMPL_H__
+
+#ifndef __UTIL_TYPES_H__
+#  error "Do not include this file directly, include util_types.h instead."
+#endif
+
+#ifndef __KERNEL_GPU__
+#  include <cstdio>
+#endif
+
 CCL_NAMESPACE_BEGIN
 
-/* RGB to Spectral Node */
-
-ccl_device void svm_node_rgb_to_spectral(
-    KernelGlobals *kg, PathState *state, float *stack, uint color_in, uint spectral_out)
+ccl_device_inline SpectralColor make_spectral_color(float value)
 {
-  /* Input */
-  RGBColor color = stack_load_float3(stack, color_in);
-  SpectralColor spectral = linear_to_wavelength_intensities(color, state->wavelengths);
-
-  stack_store_spectral(stack, spectral_out, spectral);
+  SpectralColor spectral;
+  SPECTRAL_COLOR_FOR_EACH(i)
+  {
+    spectral[i] = value;
+  }
+  return spectral;
 }
 
 CCL_NAMESPACE_END
+
+#endif /* __UTIL_TYPES_FLOAT4_IMPL_H__ */


### PR DESCRIPTION
This change makes possible using more than 3 channels per ray with datatypes like `float4` or `float8`.